### PR TITLE
mir_driver: Optionally disable the map topic + TF frame

### DIFF
--- a/mir_driver/launch/mir.launch
+++ b/mir_driver/launch/mir.launch
@@ -3,6 +3,8 @@
 
   <arg name="mir_hostname" default="192.168.12.20" />
 
+  <arg name="disable_map" default="false" doc="Disable the map topic and map -> odom_comb TF transform from the MiR" />
+
   <param name="tf_prefix" type="string" value="$(arg tf_prefix)"/>
 
   <!-- URDF -->
@@ -10,15 +12,15 @@
 
   <!-- Robot state publisher -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher">
-    <remap from="/tf"        to="tf_mir" />
-    <remap from="/tf_static" to="tf_static_mir" />
+    <remap from="/tf"        to="tf_rss" />
+    <remap from="/tf_static" to="tf_static_rss" />
   </node>
 
   <!-- remove those TFs that are also published by the MiR to avoid conflicts -->
-  <node name="tf_remove_child_frames" pkg="mir_driver" type="tf_remove_child_frames.py" output="screen">
-    <remap from="tf_in"         to="tf_mir" />
+  <node name="tf_remove_state_publisher_frames" pkg="mir_driver" type="tf_remove_child_frames.py" output="screen">
+    <remap from="tf_in"         to="tf_rss" />
     <remap from="tf_out"        to="/tf" />
-    <remap from="tf_static_in"  to="tf_static_mir" />
+    <remap from="tf_static_in"  to="tf_static_rss" />
     <remap from="tf_static_out" to="/tf_static" />
     <rosparam param="remove_frames">
       - base_link
@@ -33,15 +35,37 @@
   </node>
 
   <!-- MiR base -->
-  <node name="mir_bridge" pkg="mir_driver" type="mir_bridge.py" output="screen">
-    <param name="hostname" value="$(arg mir_hostname)" />
-    <param name="tf_prefix" value="$(arg tf_prefix)" />
-    <remap from="map" to="/map" />
-    <remap from="map_metadata" to="/map_metadata" />
-    <remap from="rosout" to="/rosout" />
-    <remap from="rosout_agg" to="/rosout_agg" />
-    <remap from="tf" to="/tf" />
-  </node>
+  <group if="$(arg disable_map)">
+    <node name="mir_bridge" pkg="mir_driver" type="mir_bridge.py" output="screen">
+      <param name="hostname" value="$(arg mir_hostname)" />
+      <param name="tf_prefix" value="$(arg tf_prefix)" />
+      <remap from="map" to="map_mir" />
+      <remap from="map_metadata" to="map_metadata_mir" />
+      <remap from="rosout" to="/rosout" />
+      <remap from="rosout_agg" to="/rosout_agg" />
+      <remap from="tf" to="tf_mir" />
+    </node>
+
+    <!-- remove the map -> odom_comb TF transform -->
+    <node name="tf_remove_mir_map_frame" pkg="mir_driver" type="tf_remove_child_frames.py" output="screen">
+      <remap from="tf_in"         to="tf_mir" />
+      <remap from="tf_out"        to="/tf" />
+      <rosparam param="remove_frames">
+        - odom_comb
+      </rosparam>
+    </node>
+  </group>
+  <group unless="$(arg disable_map)">
+    <node name="mir_bridge" pkg="mir_driver" type="mir_bridge.py" output="screen">
+      <param name="hostname" value="$(arg mir_hostname)" />
+      <param name="tf_prefix" value="$(arg tf_prefix)" />
+      <remap from="map" to="/map" />
+      <remap from="map_metadata" to="/map_metadata" />
+      <remap from="rosout" to="/rosout" />
+      <remap from="rosout_agg" to="/rosout_agg" />
+      <remap from="tf" to="/tf" />
+    </node>
+  </group>
 
   <node name="b_rep117_laser_filter" pkg="mir_driver" type="rep117_filter.py" output="screen">
     <remap from="scan" to="b_scan" />


### PR DESCRIPTION
This is useful when running one's own SLAM / localization nodes.

Fixes #5.