### PR TITLE
split parameter files for mapping/planning

### DIFF
--- a/mir_navigation/config/costmap_common_params.yaml
+++ b/mir_navigation/config/costmap_common_params.yaml
@@ -9,7 +9,7 @@ obstacle_range: 3.0
 publish_voxel_map: true
 navigation_map:
   map_topic: /map
-  first_map_only: true
+#  first_map_only: true # set in costmap_params_[mapping|planning] to true/false
 obstacles:
   observation_sources: b_scan_marking b_scan_clearing f_scan_marking f_scan_clearing
   b_scan_marking:

--- a/mir_navigation/config/costmap_common_params_mapping.yaml
+++ b/mir_navigation/config/costmap_common_params_mapping.yaml
@@ -1,0 +1,2 @@
+navigation_map:
+    first_map_only: false

--- a/mir_navigation/config/costmap_common_params_planning.yaml
+++ b/mir_navigation/config/costmap_common_params_planning.yaml
@@ -1,0 +1,2 @@
+navigation_map:
+    first_map_only: true

--- a/mir_navigation/config/costmap_global_params.yaml
+++ b/mir_navigation/config/costmap_global_params.yaml
@@ -10,8 +10,5 @@ global_costmap:
     inflation:
       cost_scaling_factor:  3.0  # Exponential rate at which the obstacle cost drops off (default: 10). Must be chosen so that the cost value is > 0 at robot's circumscribed radius.
       inflation_radius:     0.6  # Max. distance from an obstacle at which costs are incurred for planning paths. Must be > robot's circumscribed radius.
-    plugins: 
-        - {name: navigation_map, type: "costmap_2d::StaticLayer" }
-        - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
-        - {name: virtual_walls_map, type: "costmap_2d::StaticLayer" }
-        - {name: inflation,  type: "costmap_2d::InflationLayer" }
+
+    # plugins are loaded via costmap_global_params_plugins_[mapping|planning].yaml

--- a/mir_navigation/config/costmap_global_params_plugins_mapping.yaml
+++ b/mir_navigation/config/costmap_global_params_plugins_mapping.yaml
@@ -1,0 +1,5 @@
+global_costmap:
+    plugins: 
+        - {name: navigation_map, type: "costmap_2d::StaticLayer" }
+        - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
+        - {name: inflation,  type: "costmap_2d::InflationLayer" }

--- a/mir_navigation/config/costmap_global_params_plugins_planning.yaml
+++ b/mir_navigation/config/costmap_global_params_plugins_planning.yaml
@@ -1,0 +1,6 @@
+global_costmap:
+    plugins: 
+        - {name: navigation_map, type: "costmap_2d::StaticLayer" }
+        - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
+        - {name: virtual_walls_map, type: "costmap_2d::StaticLayer" }
+        - {name: inflation,  type: "costmap_2d::InflationLayer" }

--- a/mir_navigation/config/costmap_local_params.yaml
+++ b/mir_navigation/config/costmap_local_params.yaml
@@ -13,7 +13,5 @@ local_costmap:
     height: 7.0
     origin_x: 0.0
     origin_y: 0.0
-    plugins: 
-        - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
-        - {name: virtual_walls_map, type: "costmap_2d::StaticLayer" }
-        - {name: inflation,  type: "costmap_2d::InflationLayer" }
+
+    # plugins are loaded via costmap_local_params_plugins_[mapping|planning].yaml

--- a/mir_navigation/config/costmap_local_params_plugins_mapping.yaml
+++ b/mir_navigation/config/costmap_local_params_plugins_mapping.yaml
@@ -1,0 +1,4 @@
+local_costmap:
+    plugins: 
+        - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
+        - {name: inflation,  type: "costmap_2d::InflationLayer" }

--- a/mir_navigation/config/costmap_local_params_plugins_planning.yaml
+++ b/mir_navigation/config/costmap_local_params_plugins_planning.yaml
@@ -1,0 +1,5 @@
+local_costmap:
+    plugins: 
+        - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
+        - {name: virtual_walls_map, type: "costmap_2d::StaticLayer" }
+        - {name: inflation,  type: "costmap_2d::InflationLayer" }

--- a/mir_navigation/launch/move_base.xml
+++ b/mir_navigation/launch/move_base.xml
@@ -1,15 +1,27 @@
 <launch>
     <!--node ns="local_costmap" name="voxel_grid_throttle" pkg="topic_tools" type="throttle" args="messages voxel_grid 3.0 voxel_grid_throttled" /-->
     <arg name="local_planner" doc="Local planner can be either dwa, base, teb or pose"/>
+    <arg name="mapping" default="false" doc="Disables usage of virtual walls when set. Necessary when creating a new map." />
+
     <node pkg="move_base" type="move_base" respawn="false" name="move_base_node" output="screen" clear_params="true">
         <param name="SBPLLatticePlanner/primitive_filename" value="$(find mir_navigation)/mprim/unicycle_highcost_5cm.mprim" />
         <rosparam file="$(find mir_navigation)/config/move_base_common_params.yaml" command="load" />
         <rosparam file="$(find mir_navigation)/config/sbpl_global_params.yaml" command="load" />
         <rosparam file="$(find mir_navigation)/config/$(arg local_planner)_local_planner_params.yaml" command="load" />
+        <!-- global costmap params -->
         <rosparam file="$(find mir_navigation)/config/costmap_common_params.yaml" command="load" ns="global_costmap" />
-        <rosparam file="$(find mir_navigation)/config/costmap_common_params.yaml" command="load" ns="local_costmap" />
+        <rosparam file="$(find mir_navigation)/config/costmap_common_params_mapping.yaml" command="load" ns="global_costmap" if="$(arg mapping)" />
+        <rosparam file="$(find mir_navigation)/config/costmap_common_params_planning.yaml" command="load" ns="global_costmap" unless="$(arg mapping)" />
         <rosparam file="$(find mir_navigation)/config/costmap_global_params.yaml" command="load" />
+        <rosparam file="$(find mir_navigation)/config/costmap_global_params_plugins_mapping.yaml" command="load" if="$(arg mapping)" />
+        <rosparam file="$(find mir_navigation)/config/costmap_global_params_plugins_planning.yaml" command="load" unless="$(arg mapping)" />
+        <!-- local costmap params -->
+        <rosparam file="$(find mir_navigation)/config/costmap_common_params.yaml" command="load" ns="local_costmap" />
+        <rosparam file="$(find mir_navigation)/config/costmap_common_params_mapping.yaml" command="load" ns="local_costmap" if="$(arg mapping)" />
+        <rosparam file="$(find mir_navigation)/config/costmap_common_params_planning.yaml" command="load" ns="local_costmap" unless="$(arg mapping)" />
         <rosparam file="$(find mir_navigation)/config/costmap_local_params.yaml" command="load" />
+        <rosparam file="$(find mir_navigation)/config/costmap_local_params_plugins_mapping.yaml" command="load" if="$(arg mapping)" />
+        <rosparam file="$(find mir_navigation)/config/costmap_local_params_plugins_planning.yaml" command="load" unless="$(arg mapping)" />
         <remap from="map" to="/map" />
     </node>
 </launch>


### PR DESCRIPTION
When creating a new map there are no virtual walls to take into account, and if we keep the `virtual_walls_map` layer in the costmaps, move base will wait for them indefinitely. Hence this PR splits the costmap configs and adds new files for the different use cases, "planning", which includes the layer, and "mapping", which doesn't.

Also, the parameter `first_map_only` is set to false in the mapping-configs.

The `move_base.xml` is updated to include the new config files, and distinguishes between the mapping and planning cases based on the `mapping`-argument, which defaults to `false`. So I think the changes should be compatible with other existing launch files and only add the possibility to disable the virtual walls layer and set the first\_map\_only to false with one argument.