### PR TITLE
Fix virtual walls

### DIFF
--- a/mir_navigation/config/costmap_local_params_plugins_virtual_walls.yaml
+++ b/mir_navigation/config/costmap_local_params_plugins_virtual_walls.yaml
@@ -1,5 +1,5 @@
 local_costmap:
     plugins: 
-        - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
         - {name: virtual_walls_map, type: "costmap_2d::StaticLayer" }
+        - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
         - {name: inflation,  type: "costmap_2d::InflationLayer" }

--- a/mir_navigation/launch/start_maps.launch
+++ b/mir_navigation/launch/start_maps.launch
@@ -1,12 +1,13 @@
 <launch>
   <arg name="map_file" default="$(find mir_gazebo)/maps/maze.yaml" doc="Path to a map .yaml file (required)." />
   <arg name="virtual_walls_map_file" default="$(arg map_file)" doc="Path to a virtual walls map .yaml file (optional)." />
+  <arg name="with_virtual_walls" default="true" />
 
   <node name="static_map_server" pkg="map_server" type="map_server" args="$(arg map_file)" ns="/" output="screen">
     <param name="frame_id" type="string" value="/map"/>
   </node>
 
-  <node name="virtual_walls_map_server" pkg="map_server" type="map_server" args="$(arg virtual_walls_map_file)" ns="/virtual_walls" output="screen">
+  <node if="$(arg with_virtual_walls)" name="virtual_walls_map_server" pkg="map_server" type="map_server" args="$(arg virtual_walls_map_file)" ns="/virtual_walls" output="screen">
     <param name="frame_id" type="string" value="/map"/>
   </node>
 </launch>

--- a/mir_navigation/launch/start_planner.launch
+++ b/mir_navigation/launch/start_planner.launch
@@ -2,13 +2,16 @@
   <arg name="local_planner"          default="dwa"             doc="Local planner can be either dwa, eband, base, teb or pose" />
   <arg name="map_file" default="$(find mir_gazebo)/maps/maze.yaml" doc="Path to a map .yaml file (required)." />
   <arg name="virtual_walls_map_file" default="$(arg map_file)" doc="Path to a virtual walls map .yaml file (optional)." />
+  <arg name="with_virtual_walls" default="true" />
 
   <include file="$(find mir_navigation)/launch/start_maps.launch">
     <arg name="map_file" value="$(arg map_file)" />
     <arg name="virtual_walls_map_file" value="$(arg virtual_walls_map_file)" />
+    <arg name="with_virtual_walls" value="$(arg with_virtual_walls)" />
   </include>
 
   <include file="$(find mir_navigation)/launch/move_base.xml">
     <arg name="local_planner" value="$(arg local_planner)"/>
+    <arg name="with_virtual_walls" value="$(arg with_virtual_walls)" />
   </include>
 </launch>


### PR DESCRIPTION
The previous configuration of the local costmap didn't work for me -- obstacles seen in the laser scans were not added, or were overridden by the virtual\_walls\_map layer. Reordering the layers and loading the virtual walls before the obstacles fixes this for me.

Also, I added a `with_virtual_walls` parameter to `start_maps.launch` and `start_planner.launch`.