### PR TITLE
adds tf_prefix argument to imu.gazebo.urdf.xacro

### DIFF
--- a/mir_description/urdf/include/imu.gazebo.urdf.xacro
+++ b/mir_description/urdf/include/imu.gazebo.urdf.xacro
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- If tf_prefix is given, use "frame tf_prefix/imu_frame", else "imu_frame" -->
+  <xacro:arg name="tf_prefix" default="" />
+  <xacro:if value="$(eval tf_prefix == '')">
+      <xacro:property name="imu_frame" value="imu_frame" />
+  </xacro:if>
+  <xacro:unless value="$(eval tf_prefix == '')">
+      <xacro:property name="imu_frame" value="$(arg tf_prefix)/imu_frame" />
+  </xacro:unless>
 
   <xacro:macro name="imu_gazebo" params="link imu_topic update_rate stdev">
     <gazebo reference="${link}">
@@ -17,7 +25,7 @@
           <gaussianNoise>${stdev * stdev}</gaussianNoise>
           <xyzOffset>0 0 0</xyzOffset>
           <rpyOffset>0 0 0</rpyOffset>
-          <frameName>imu_frame</frameName>  <!-- from real MiR -->
+          <frameName>${imu_frame}</frameName>  <!-- from real MiR -->
         </plugin>
         <pose>0 0 0 0 0 0</pose>
       </sensor>

--- a/mir_description/urdf/include/imu.gazebo.urdf.xacro
+++ b/mir_description/urdf/include/imu.gazebo.urdf.xacro
@@ -3,10 +3,11 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- If tf_prefix is given, use "frame tf_prefix/imu_frame", else "imu_frame" -->
   <xacro:arg name="tf_prefix" default="" />
-  <xacro:if value="$(eval tf_prefix == '')">
+  <xacro:property name="tf_prefix" value="$(arg tf_prefix)" />
+  <xacro:if value="${tf_prefix == ''}">
       <xacro:property name="imu_frame" value="imu_frame" />
   </xacro:if>
-  <xacro:unless value="$(eval tf_prefix == '')">
+  <xacro:unless value="${tf_prefix == ''}">
       <xacro:property name="imu_frame" value="$(arg tf_prefix)/imu_frame" />
   </xacro:unless>
 


### PR DESCRIPTION
When creating the urdf description of the robot, use the `tf_prefix` argument to make the imu plugin publish it's data in the `tf_prefix/imu_frame`.

Works in nested models, since `xacro:arg`s seem to work like global variables (kind of). E.g., our mobipick robot includes the mir, and with no further modifications sets the tf\_prefix of the mir's IMU like this:
```xml
<param name="robot_description" command="$(find xacro)/xacro --inorder $(find mobipick_description)/urdf/mobipick/mobipick_v1_model.urdf.xacro tf_prefix:=mobipick" />
```