### PR TITLE
Add prefix argument to configs

### DIFF
--- a/mir_description/config/diffdrive_controller.yaml
+++ b/mir_description/config/diffdrive_controller.yaml
@@ -1,8 +1,8 @@
 # -----------------------------------
 mobile_base_controller:
   type        : "diff_drive_controller/DiffDriveController"
-  left_wheel  : 'left_wheel_joint'
-  right_wheel : 'right_wheel_joint'
+  left_wheel  : '$(arg prefix)left_wheel_joint'
+  right_wheel : '$(arg prefix)right_wheel_joint'
   publish_rate: 41.2               # this is what the real MiR platform publishes (default: 50)
   # These covariances are exactly what the real MiR platform publishes
   pose_covariance_diagonal : [0.00001, 0.00001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
@@ -23,8 +23,8 @@ mobile_base_controller:
   cmd_vel_timeout: 0.5
 
   # frame_ids (same as real MiR platform)
-  base_frame_id: base_footprint # default: base_link
-  odom_frame_id: odom_comb      # default: odom
+  base_frame_id: $(arg prefix)base_footprint # default: base_link
+  odom_frame_id: $(arg prefix)odom_comb      # default: odom
 
   # Velocity and acceleration limits
   # Whenever a min_* is unspecified, default to -max_*

--- a/mir_description/urdf/include/imu.gazebo.urdf.xacro
+++ b/mir_description/urdf/include/imu.gazebo.urdf.xacro
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- If tf_prefix is given, use "frame tf_prefix/imu_frame", else "imu_frame" -->
+  <xacro:arg name="tf_prefix" default="" />
+  <xacro:if value="$(eval tf_prefix == '')">
+      <xacro:property name="imu_frame" value="imu_frame" />
+  </xacro:if>
+  <xacro:unless value="$(eval tf_prefix == '')">
+      <xacro:property name="imu_frame" value="$(arg tf_prefix)/imu_frame" />
+  </xacro:unless>
 
   <xacro:macro name="imu_gazebo" params="link imu_topic update_rate stdev">
     <gazebo reference="${link}">
@@ -17,7 +25,7 @@
           <gaussianNoise>${stdev * stdev}</gaussianNoise>
           <xyzOffset>0 0 0</xyzOffset>
           <rpyOffset>0 0 0</rpyOffset>
-          <frameName>imu_frame</frameName>  <!-- from real MiR -->
+          <frameName>${imu_frame}</frameName>  <!-- from real MiR -->
         </plugin>
         <pose>0 0 0 0 0 0</pose>
       </sensor>

--- a/mir_description/urdf/include/imu.gazebo.urdf.xacro
+++ b/mir_description/urdf/include/imu.gazebo.urdf.xacro
@@ -3,10 +3,11 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- If tf_prefix is given, use "frame tf_prefix/imu_frame", else "imu_frame" -->
   <xacro:arg name="tf_prefix" default="" />
-  <xacro:if value="$(eval tf_prefix == '')">
+  <xacro:property name="tf_prefix" value="$(arg tf_prefix)" />
+  <xacro:if value="${tf_prefix == ''}">
       <xacro:property name="imu_frame" value="imu_frame" />
   </xacro:if>
-  <xacro:unless value="$(eval tf_prefix == '')">
+  <xacro:unless value="${tf_prefix == ''}">
       <xacro:property name="imu_frame" value="$(arg tf_prefix)/imu_frame" />
   </xacro:unless>
 

--- a/mir_description/urdf/include/mir_100_v1.urdf.xacro
+++ b/mir_description/urdf/include/mir_100_v1.urdf.xacro
@@ -192,7 +192,7 @@
       <child link="${prefix}front_laser_link" />
       <origin xyz="0.4288 0.2358 0.1914" rpy="0.0 0.0 ${0.25 * pi}" />  <!-- from visually matching up the meshes of the MiR and the laser scanner -->
     </joint>
-    <xacro:sick_s300 link="${prefix}front_laser_link" topic="f_scan" />
+    <xacro:sick_s300 prefix="${prefix}" link="front_laser_link" topic="f_scan" />
 
     <joint name="${prefix}base_link_to_back_laser_joint" type="fixed">
       <parent link="${prefix}base_link" />
@@ -200,7 +200,7 @@
       <origin xyz="-0.3548 -0.2352 0.1914" rpy="0.0 0.0 ${-0.75 * pi}" />  <!-- from visually matching up the meshes of the MiR and the laser scanner -->
     </joint>
 
-    <xacro:sick_s300 link="${prefix}back_laser_link" topic="b_scan" />
+    <xacro:sick_s300 prefix="${prefix}" link="back_laser_link" topic="b_scan" />
 
     <!-- Ultrasound sensors -->
     <joint name="${prefix}us_1_joint" type="fixed">   <!-- right ultrasound -->

--- a/mir_description/urdf/include/sick_s300.urdf.xacro
+++ b/mir_description/urdf/include/sick_s300.urdf.xacro
@@ -8,8 +8,8 @@
   <xacro:property name="laser_z" value="0.185" />
   <xacro:property name="laser_mass" value="2.0" />
 
-  <xacro:macro name="sick_s300" params="link topic">
-    <link name="${link}">
+  <xacro:macro name="sick_s300" params="link topic prefix">
+    <link name="${prefix}${link}">
       <visual>
         <origin xyz="0.0 0.0 0.0" rpy="${pi} 0 0" />
         <geometry>
@@ -29,11 +29,11 @@
       </xacro:box_inertial>
     </link>
 
-    <gazebo reference="${link}">
+    <gazebo reference="${prefix}${link}">
       <!-- <material value="Gazebo/Yellow" /> -->
       <material value="Gazebo/FlatBlack" />
 
-      <sensor type="gpu_ray" name="${link}">
+      <sensor type="gpu_ray" name="${prefix}${link}">
         <pose>0 0 0 0 0 0</pose>
         <visualize>false</visualize>
         <update_rate>12.5</update_rate>
@@ -61,6 +61,7 @@
           </noise>
         </ray>
         <plugin name="gazebo_ros_${link}_controller" filename="libgazebo_ros_gpu_laser.so">
+          <!-- no prefix, plugin always uses a tf_prefix (if none is set it uses robotNamespace) -->
           <frameName>${link}</frameName>
           <topicName>${topic}</topicName>
         </plugin>

--- a/mir_gazebo/config/ekf.yaml
+++ b/mir_gazebo/config/ekf.yaml
@@ -61,9 +61,9 @@ publish_acceleration: false
 #     3b. MAKE SURE something else is generating the odom->base_link transform. Note that this can even be another state
 #         estimation node from robot_localization! However, that instance should *not* fuse the global data.
 map_frame: map                   # Defaults to "map" if unspecified
-odom_frame: odom_comb            # Defaults to "odom" if unspecified
-base_link_frame: base_footprint  # Defaults to "base_link" if unspecified
-world_frame: odom_comb           # Defaults to the value of odom_frame if unspecified
+odom_frame: $(arg tf_prefix)odom_comb            # Defaults to "odom" if unspecified
+base_link_frame: $(arg tf_prefix)base_footprint  # Defaults to "base_link" if unspecified
+world_frame: $(arg tf_prefix)odom_comb           # Defaults to the value of odom_frame if unspecified
 
 # The filter accepts an arbitrary number of inputs from each input message type (nav_msgs/Odometry,
 # geometry_msgs/PoseWithCovarianceStamped, geometry_msgs/TwistWithCovarianceStamped,

--- a/mir_gazebo/launch/includes/ekf.launch.xml
+++ b/mir_gazebo/launch/includes/ekf.launch.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="tf_prefix" default="" />
   <node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization_node" clear_params="true" output="screen">
-    <rosparam command="load" file="$(find mir_gazebo)/config/ekf.yaml" />
+    <rosparam command="load" file="$(find mir_gazebo)/config/ekf.yaml" subst_value="true" />
   </node>
 </launch>

--- a/mir_gazebo/launch/mir_gazebo_common.launch
+++ b/mir_gazebo/launch/mir_gazebo_common.launch
@@ -3,6 +3,7 @@
   <arg name="robot_x"   default="0.0" />
   <arg name="robot_y"   default="0.0" />
   <arg name="robot_yaw" default="0.0" />
+  <arg name="prefix"    default="" />
 
   <!-- Load URDF -->
   <include file="$(find mir_description)/launch/upload_mir_urdf.launch" />
@@ -13,7 +14,7 @@
 
   <!-- Load ros_control controller configurations -->
   <rosparam file="$(find mir_description)/config/joint_state_controller.yaml" command="load" />
-  <rosparam file="$(find mir_description)/config/diffdrive_controller.yaml" command="load" />
+  <rosparam file="$(find mir_description)/config/diffdrive_controller.yaml" command="load" subst_value="true" />
 
   <!-- Start the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" output="screen"

--- a/mir_navigation/config/costmap_common_params.yaml
+++ b/mir_navigation/config/costmap_common_params.yaml
@@ -1,4 +1,4 @@
-robot_base_frame: base_footprint
+robot_base_frame: $(arg prefix)base_footprint
 transform_tolerance: 0.4
 update_frequency: 5.0
 publish_frequency: 1.0

--- a/mir_navigation/config/costmap_local_params.yaml
+++ b/mir_navigation/config/costmap_local_params.yaml
@@ -1,5 +1,5 @@
 local_costmap:
-    global_frame: odom_comb
+    global_frame: $(arg prefix)odom_comb
     static_map: false
     rolling_window: true
     raytrace_range: 6.0

--- a/mir_navigation/launch/move_base.xml
+++ b/mir_navigation/launch/move_base.xml
@@ -2,6 +2,7 @@
     <!--node ns="local_costmap" name="voxel_grid_throttle" pkg="topic_tools" type="throttle" args="messages voxel_grid 3.0 voxel_grid_throttled" /-->
     <arg name="local_planner" doc="Local planner can be either dwa, base, teb or pose"/>
     <arg name="with_virtual_walls" default="true" doc="Enables usage of virtual walls when set. Set to false when running SLAM." />
+    <arg name="prefix" default="" doc="Prefix used for robot tf frames" /> <!-- used in the config files -->
 
     <node pkg="move_base" type="move_base" respawn="false" name="move_base_node" output="screen" clear_params="true">
         <param name="SBPLLatticePlanner/primitive_filename" value="$(find mir_navigation)/mprim/unicycle_highcost_5cm.mprim" />
@@ -9,13 +10,13 @@
         <rosparam file="$(find mir_navigation)/config/sbpl_global_params.yaml" command="load" />
         <rosparam file="$(find mir_navigation)/config/$(arg local_planner)_local_planner_params.yaml" command="load" />
         <!-- global costmap params -->
-        <rosparam file="$(find mir_navigation)/config/costmap_common_params.yaml" command="load" ns="global_costmap" />
+        <rosparam file="$(find mir_navigation)/config/costmap_common_params.yaml" command="load" ns="global_costmap" subst_value="true" />
         <rosparam file="$(find mir_navigation)/config/costmap_global_params.yaml" command="load" />
         <rosparam file="$(find mir_navigation)/config/costmap_global_params_plugins_virtual_walls.yaml" command="load" if="$(arg with_virtual_walls)" />
         <rosparam file="$(find mir_navigation)/config/costmap_global_params_plugins_no_virtual_walls.yaml" command="load" unless="$(arg with_virtual_walls)" />
         <!-- local costmap params -->
-        <rosparam file="$(find mir_navigation)/config/costmap_common_params.yaml" command="load" ns="local_costmap" />
-        <rosparam file="$(find mir_navigation)/config/costmap_local_params.yaml" command="load" />
+        <rosparam file="$(find mir_navigation)/config/costmap_common_params.yaml" command="load" ns="local_costmap" subst_value="true" />
+        <rosparam file="$(find mir_navigation)/config/costmap_local_params.yaml" command="load" subst_value="true" />
         <rosparam file="$(find mir_navigation)/config/costmap_local_params_plugins_virtual_walls.yaml" command="load" if="$(arg with_virtual_walls)" />
         <rosparam file="$(find mir_navigation)/config/costmap_local_params_plugins_no_virtual_walls.yaml" command="load" unless="$(arg with_virtual_walls)" />
         <remap from="map" to="/map" />


### PR DESCRIPTION
(extends #15)

This PR adds ways to parameterize move\_base et al. with a tf prefix, in cases where a simple rosparam `tf_prefix` does not work. (And it doesn't because of parts of MoveIt!, e.g. the PlanningSceneMonitor, ignore the `tf_prefix`).

**TODO**
I did not check if this breaks anything. There might be some launchfiles which do not substitute the `$(arg prefix)` when loading the yaml files.