### PR TITLE
re-added gazebo friction parameters for the wheels

### DIFF
--- a/mir_description/urdf/include/mir_100.gazebo.xacro
+++ b/mir_description/urdf/include/mir_100.gazebo.xacro
@@ -32,6 +32,7 @@
       <mu2 value="${friction}"/>
       <kp value="10000000.0"/>
       <kd value="1.0"/>
+      <minDepth>0.01</minDepth>
     </gazebo>
   </xacro:macro>
 

--- a/mir_description/urdf/include/mir_100_v1.urdf.xacro
+++ b/mir_description/urdf/include/mir_100_v1.urdf.xacro
@@ -238,8 +238,8 @@
 
     <xacro:mir_100_wheel_transmissions prefix="${prefix}"/>
 
-    <!-- disabled, because it doesn't make a difference in Gazebo: -->
-    <!-- <xacro:set_all_wheel_frictions prefix="${prefix}"/> -->
+    <!-- set the gazebo friction parameters for the wheels -->
+    <xacro:set_all_wheel_frictions prefix="${prefix}"/>
 
     <p3d_base_controller prefix="${prefix}" />
   </xacro:macro>


### PR DESCRIPTION
they were removed previously with a comment that they wouldn't
change anything; but re-adding them (and also providing a minDepth[1]
value!) stops the robot from sliding over the ground plane when
it should stand still.

[1] http://answers.gazebosim.org/question/17457/robot-slips-after-upgrade-to-kinetic/?answer=17487#post-id-17487