### PR TITLE
Fix: Changes tf message type to tf2.

### DIFF
--- a/mir_driver/nodes/mir_bridge.py
+++ b/mir_driver/nodes/mir_bridge.py
@@ -215,6 +215,7 @@ PUB_TOPICS = [
               TopicConfig('scan', LaserScan),
               TopicConfig('scan_filter/visualization_marker', Marker),
               TopicConfig('tf', tfMessage, dict_filter=_tf_dict_filter),
+              TopicConfig('tf_static', tfMessage, dict_filter=_tf_dict_filter),
               TopicConfig('transform_footprint/parameter_descriptions', ConfigDescription),
               TopicConfig('transform_footprint/parameter_updates', Config),
               TopicConfig('transform_imu/parameter_descriptions', ConfigDescription),


### PR DESCRIPTION
We noticed that the MIR is publishing messages in tf2. This is one way that works from us, but one might want to use one of those rewrite functions.

I am not too familiar with this software stack, so I leave it to you.