### PR TITLE
prefix for move base configs

### DIFF
--- a/mir_navigation/launch/start_planner.launch
+++ b/mir_navigation/launch/start_planner.launch
@@ -3,6 +3,7 @@
   <arg name="map_file" default="$(find mir_gazebo)/maps/maze.yaml" doc="Path to a map .yaml file (required)." />
   <arg name="virtual_walls_map_file" default="$(arg map_file)" doc="Path to a virtual walls map .yaml file (optional)." />
   <arg name="with_virtual_walls" default="true" />
+  <arg name="prefix" default="/" />
 
   <include file="$(find mir_navigation)/launch/start_maps.launch">
     <arg name="map_file" value="$(arg map_file)" />
@@ -13,5 +14,6 @@
   <include file="$(find mir_navigation)/launch/move_base.xml">
     <arg name="local_planner" value="$(arg local_planner)"/>
     <arg name="with_virtual_walls" value="$(arg with_virtual_walls)" />
+    <arg name="prefix" value="$(arg prefix)" />
   </include>
 </launch>


### PR DESCRIPTION
Use prefix argument to set prefix in move base config files for mir_navigation.