### PR TITLE
Remove MirStatus.msg from CmakeLists.txt

### DIFF
--- a/mir_msgs/CMakeLists.txt
+++ b/mir_msgs/CMakeLists.txt
@@ -35,7 +35,6 @@ add_message_files(
     JoystickVel.msg
     LocalMapStat.msg
     MirExtra.msg
-    MirStatus.msg
     MissionCtrlCommand.msg
     MissionCtrlState.msg
     PalletLifterStatus.msg


### PR DESCRIPTION
Branch melodic-2.8 doesn't build because the msg definition was removed, but it was still listed in the CMakeLists.txt