### PR TITLE
Add gazebo_plugins to dependency list

### DIFF
--- a/mir_description/package.xml
+++ b/mir_description/package.xml
@@ -18,6 +18,7 @@
   <build_depend>roslaunch</build_depend>
 
   <exec_depend>diff_drive_controller</exec_depend>
+  <exec_depend>gazebo_plugins</exec_depend>
   <exec_depend>gazebo_ros_control</exec_depend>
   <exec_depend>hector_gazebo_plugins</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>


### PR DESCRIPTION
I needed to add this package, which provides the [p3d plugin for the ground truth pose output](https://github.com/dfki-ric/mir_robot/blob/noetic/mir_description/urdf/include/mir_100.gazebo.xacro#L48).