### PR TITLE
Fix: Prevent fake joint publisher from publishing TF_REPEATED_DATA

### DIFF
--- a/mir_driver/nodes/fake_mir_joint_publisher.py
+++ b/mir_driver/nodes/fake_mir_joint_publisher.py
@@ -7,22 +7,32 @@ def fake_mir_joint_publisher():
     rospy.init_node('fake_mir_joint_publisher')
     prefix = rospy.get_param('~prefix', '')
     pub = rospy.Publisher('joint_states', JointState, queue_size=10)
+    publish_wheel_joints = rospy.get_param('~publish_wheel_joints', True)
     r = rospy.Rate(50.0)
+    t = None
     while not rospy.is_shutdown():
         js = JointState()
         js.header.stamp = rospy.Time.now()
-        js.name = [
-            prefix + 'left_wheel_joint',
-            prefix + 'right_wheel_joint',
-            prefix + 'fl_caster_rotation_joint',
-            prefix + 'fl_caster_wheel_joint',
-            prefix + 'fr_caster_rotation_joint',
-            prefix + 'fr_caster_wheel_joint',
-            prefix + 'bl_caster_rotation_joint',
-            prefix + 'bl_caster_wheel_joint',
-            prefix + 'br_caster_rotation_joint',
-            prefix + 'br_caster_wheel_joint',
-        ]
+        if js.header.stamp == t:
+            rospy.loginfo("Timestamp identical: %s, %s", js.header.stamp, t)
+            r.sleep()
+            continue
+
+        t = js.header.stamp
+        js.name = [prefix + 'fl_caster_rotation_joint',
+                   prefix + 'fl_caster_wheel_joint',
+                   prefix + 'fr_caster_rotation_joint',
+                   prefix + 'fr_caster_wheel_joint',
+                   prefix + 'bl_caster_rotation_joint',
+                   prefix + 'bl_caster_wheel_joint',
+                   prefix + 'br_caster_rotation_joint',
+                   prefix + 'br_caster_wheel_joint',
+                   ]
+        if (publish_wheel_joints):
+            js.name.extend([
+                prefix + 'left_wheel_joint',
+                prefix + 'right_wheel_joint',
+            ])
         js.position = [0.0 for _ in js.name]
         js.velocity = [0.0 for _ in js.name]
         js.effort = [0.0 for _ in js.name]


### PR DESCRIPTION
- During startup it can happen that the clock does not increase. Checking the time prevents double-sending to "joint_states"
- In some configuration Gazebo also published data for the wheel leading to collisions with this publisher creating these msgs:
"TF_REPEATED_DATA ignoring data with redundant timestamp for frame mir/left_wheel_link at time 45.782000"

This spams the log a lot. This patch allows to configure the fake_mir_joint_publisher to only publish the caster wheels.
In our setup in noetic this is needed. I think it's the `joint_state_publisher` that typically publishes these, e.g. from Gazebo.