### PR TITLE
Add DWB path_follower critic

### DIFF
--- a/mir_dwb_critics/CMakeLists.txt
+++ b/mir_dwb_critics/CMakeLists.txt
@@ -32,6 +32,7 @@ include_directories(
 add_library(${PROJECT_NAME}
   src/path_angle.cpp
   src/path_progress.cpp
+  src/path_follower.cpp
   src/path_dist_pruned.cpp
 )
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})

--- a/mir_dwb_critics/default_critics.xml
+++ b/mir_dwb_critics/default_critics.xml
@@ -8,18 +8,6 @@
            base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Maintains advanced path following behavior with articulation handling and pose alignment logic.</description>
     </class>
-    <class name="mir_dwb_critics::PathFollowerCritic" type="mir_dwb_critics::PathFollowerCritic"
-           base_class_type="dwb_local_planner::TrajectoryCritic">
-      <description>Compatibility alias for the PathFollower critic.</description>
-    </class>
-    <class name="PathFollower" type="mir_dwb_critics::PathFollowerCritic"
-           base_class_type="dwb_local_planner::TrajectoryCritic">
-      <description>Compatibility alias for legacy configurations referencing PathFollower without a namespace.</description>
-    </class>
-    <class name="PathFollowerCritic" type="mir_dwb_critics::PathFollowerCritic"
-           base_class_type="dwb_local_planner::TrajectoryCritic">
-      <description>Compatibility alias for legacy configurations referencing PathFollowerCritic without a namespace.</description>
-    </class>
     <class type="mir_dwb_critics::PathAngleCritic" base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Scores trajectories based on the difference between the path's current angle and the trajectory's angle</description>
     </class>

--- a/mir_dwb_critics/default_critics.xml
+++ b/mir_dwb_critics/default_critics.xml
@@ -1,12 +1,11 @@
 <class_libraries>
   <library path="lib/libmir_dwb_critics">
-    <class name="mir_dwb_critics::PathProgress" type="mir_dwb_critics::PathProgressCritic"
-           base_class_type="dwb_local_planner::TrajectoryCritic">
+    <class type="mir_dwb_critics::PathProgressCritic" base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Scores trajectories based on how far along the global path they end up.</description>
     </class>
     <class name="mir_dwb_critics::PathFollowerCritic" type="mir_dwb_critics::PathFollowerCritic"
            base_class_type="dwb_local_planner::TrajectoryCritic">
-      <description>Maintains advanced path following behavior with articulation handling and pose alignment logic.</description>
+      <description>Close path following behavior with articulation handling and pose alignment logic.</description>
     </class>
     <class type="mir_dwb_critics::PathAngleCritic" base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Scores trajectories based on the difference between the path's current angle and the trajectory's angle</description>

--- a/mir_dwb_critics/default_critics.xml
+++ b/mir_dwb_critics/default_critics.xml
@@ -1,7 +1,12 @@
 <class_libraries>
   <library path="lib/libmir_dwb_critics">
-    <class type="mir_dwb_critics::PathProgressCritic" base_class_type="dwb_local_planner::TrajectoryCritic">
+    <class name="mir_dwb_critics::PathProgress" type="mir_dwb_critics::PathProgressCritic"
+           base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Scores trajectories based on how far along the global path they end up.</description>
+    </class>
+    <class name="mir_dwb_critics::PathFollower" type="mir_dwb_critics::PathFollowerCritic"
+           base_class_type="dwb_local_planner::TrajectoryCritic">
+      <description>Maintains advanced path following behavior with articulation handling and pose alignment logic.</description>
     </class>
     <class type="mir_dwb_critics::PathAngleCritic" base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Scores trajectories based on the difference between the path's current angle and the trajectory's angle</description>

--- a/mir_dwb_critics/default_critics.xml
+++ b/mir_dwb_critics/default_critics.xml
@@ -8,6 +8,10 @@
            base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Maintains advanced path following behavior with articulation handling and pose alignment logic.</description>
     </class>
+    <class name="mir_dwb_critics::PathFollowerCritic" type="mir_dwb_critics::PathFollowerCritic"
+           base_class_type="dwb_local_planner::TrajectoryCritic">
+      <description>Compatibility alias for the PathFollower critic.</description>
+    </class>
     <class type="mir_dwb_critics::PathAngleCritic" base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Scores trajectories based on the difference between the path's current angle and the trajectory's angle</description>
     </class>

--- a/mir_dwb_critics/default_critics.xml
+++ b/mir_dwb_critics/default_critics.xml
@@ -12,6 +12,10 @@
            base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Compatibility alias for the PathFollower critic.</description>
     </class>
+    <class name="PathFollowerCritic" type="mir_dwb_critics::PathFollowerCritic"
+           base_class_type="dwb_local_planner::TrajectoryCritic">
+      <description>Compatibility alias for legacy configurations referencing PathFollowerCritic without a namespace.</description>
+    </class>
     <class type="mir_dwb_critics::PathAngleCritic" base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Scores trajectories based on the difference between the path's current angle and the trajectory's angle</description>
     </class>

--- a/mir_dwb_critics/default_critics.xml
+++ b/mir_dwb_critics/default_critics.xml
@@ -12,6 +12,10 @@
            base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Compatibility alias for the PathFollower critic.</description>
     </class>
+    <class name="PathFollower" type="mir_dwb_critics::PathFollowerCritic"
+           base_class_type="dwb_local_planner::TrajectoryCritic">
+      <description>Compatibility alias for legacy configurations referencing PathFollower without a namespace.</description>
+    </class>
     <class name="PathFollowerCritic" type="mir_dwb_critics::PathFollowerCritic"
            base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Compatibility alias for legacy configurations referencing PathFollowerCritic without a namespace.</description>

--- a/mir_dwb_critics/default_critics.xml
+++ b/mir_dwb_critics/default_critics.xml
@@ -4,7 +4,7 @@
            base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Scores trajectories based on how far along the global path they end up.</description>
     </class>
-    <class name="mir_dwb_critics::PathFollower" type="mir_dwb_critics::PathFollowerCritic"
+    <class name="mir_dwb_critics::PathFollowerCritic" type="mir_dwb_critics::PathFollowerCritic"
            base_class_type="dwb_local_planner::TrajectoryCritic">
       <description>Maintains advanced path following behavior with articulation handling and pose alignment logic.</description>
     </class>

--- a/mir_dwb_critics/include/mir_dwb_critics/path_follower.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_follower.h
@@ -79,8 +79,8 @@ protected:
 
   bool hasForwardProgress(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index) const;
 
-  bool isPoseReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
-                     double goal_yaw, double xy_tolerance, double yaw_tolerance) const;
+  bool isPoseReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose, double goal_yaw,
+                     double xy_tolerance, double yaw_tolerance) const;
 
   bool isGoalReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
                      double goal_yaw) const;

--- a/mir_dwb_critics/include/mir_dwb_critics/path_follower.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_follower.h
@@ -94,7 +94,7 @@ protected:
   double heading_scale_;
   bool enforce_forward_dot_;
   bool always_target_articulations_;
-  double intermediate_goal_spacing_;
+  unsigned int intermediate_goal_spacing_;
   bool initial_alignment_done_;
 
   // Plan change detection to reset internal state on new global plans

--- a/mir_dwb_critics/include/mir_dwb_critics/path_follower.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_follower.h
@@ -31,16 +31,23 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef MIR_DWB_CRITICS_PATH_PROGRESS_H_
-#define MIR_DWB_CRITICS_PATH_PROGRESS_H_
+#ifndef MIR_DWB_CRITICS_PATH_FOLLOWER_H_
+#define MIR_DWB_CRITICS_PATH_FOLLOWER_H_
 
 #include <dwb_critics/map_grid.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <sensor_msgs/PointCloud.h>
+#include <visualization_msgs/MarkerArray.h>
+#include <ros/publisher.h>
+#include <ros/time.h>
+#include <cstdint>
+#include <string>
 #include <vector>
 
 namespace mir_dwb_critics
 {
 /**
- * @class PathProgressCritic
+ * @class PathFollowerCritic
  * @brief Calculates an intermediate goal along the global path and scores trajectories on the distance to that goal.
  *
  * This trajectory critic helps ensure progress along the global path. It
@@ -48,7 +55,7 @@ namespace mir_dwb_critics
  * path as long as the path continues to move in one direction (+/-
  * angle_threshold).
  */
-class PathProgressCritic : public dwb_critics::MapGridCritic
+class PathFollowerCritic : public dwb_critics::MapGridCritic
 {
 public:
   bool prepare(const geometry_msgs::Pose2D& pose, const nav_2d_msgs::Twist2D& vel, const geometry_msgs::Pose2D& goal,
@@ -59,19 +66,64 @@ public:
   double scoreTrajectory(const dwb_msgs::Trajectory2D& traj) override;
 
 protected:
-  bool getGoalPose(const geometry_msgs::Pose2D& robot_pose, const nav_2d_msgs::Path2D& global_plan, unsigned int& x,
-                   unsigned int& y, double& desired_angle);
+  bool getGoalPose(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& final_goal,
+                   const nav_2d_msgs::Path2D& global_plan, unsigned int& x, unsigned int& y, double& desired_angle);
 
   unsigned int getGoalIndex(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
-                            unsigned int last_valid_index) const;
+                            unsigned int last_valid_index, bool plan_tail_is_final_goal, double& desired_angle,
+                            bool& has_forward_direction) const;
+
+  bool findNextArticulation(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
+                            unsigned int end_index, unsigned int last_valid_index, unsigned int& articulation_index,
+                            double& articulation_yaw, bool& has_forward_direction) const;
+
+  bool computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,
+                            double& angle) const;
+
+  bool isPoseReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
+                     double goal_yaw, double xy_tolerance, double yaw_tolerance) const;
+
+  bool isGoalReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
+                     double goal_yaw) const;
 
   double xy_local_goal_tolerance_;
+  double yaw_local_goal_tolerance_;
+  double final_goal_yaw_tolerance_;
+  double final_goal_xy_tolerance_;
   double angle_threshold_;
+  double articulation_angle_threshold_;
   double heading_scale_;
+  bool enforce_forward_dot_;
+  bool always_target_articulations_;
+  bool initial_alignment_done_;
+
+  // Plan change detection to reset internal state on new global plans
+  bool have_last_plan_;
+  size_t last_plan_size_;
+  geometry_msgs::Pose2D last_plan_end_pose_;
+  std::string last_plan_frame_id_;
+  ros::Time last_plan_stamp_;
+  uint32_t last_plan_seq_;
+  geometry_msgs::Pose2D last_plan_start_pose_;
+  geometry_msgs::Pose2D last_final_goal_pose_;
+  bool have_last_goal_pose_;
+
+  double plan_alignment_position_tolerance_;
+  double plan_alignment_yaw_tolerance_;
+
+  unsigned int last_progress_index_;
+  bool holding_goal_;
+  unsigned int held_goal_index_;
+  geometry_msgs::Pose2D held_goal_pose_;
+  double hold_position_epsilon_;
+  double hold_yaw_epsilon_;
 
   std::vector<geometry_msgs::Pose2D> reached_intermediate_goals_;
   double desired_angle_;
+  ros::Publisher intermediate_goal_pub_;
+  ros::Publisher articulation_points_pub_;
+  ros::Publisher intermediate_goal_tolerance_pub_;
 };
 
 }  // namespace mir_dwb_critics
-#endif  // MIR_DWB_CRITICS_PATH_PROGRESS_H_
+#endif  // MIR_DWB_CRITICS_PATH_FOLLOWER_H_

--- a/mir_dwb_critics/include/mir_dwb_critics/path_follower.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_follower.h
@@ -77,8 +77,7 @@ protected:
                             unsigned int end_index, unsigned int last_valid_index, unsigned int& articulation_index,
                             double& articulation_yaw, bool& has_forward_direction) const;
 
-  bool computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,
-                            double& angle) const;
+  bool hasForwardProgress(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index) const;
 
   bool isPoseReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
                      double goal_yaw, double xy_tolerance, double yaw_tolerance) const;
@@ -95,6 +94,7 @@ protected:
   double heading_scale_;
   bool enforce_forward_dot_;
   bool always_target_articulations_;
+  double intermediate_goal_spacing_;
   bool initial_alignment_done_;
 
   // Plan change detection to reset internal state on new global plans

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -37,6 +37,7 @@
 #include <dwb_critics/map_grid.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <sensor_msgs/PointCloud.h>
+#include <visualization_msgs/MarkerArray.h>
 #include <ros/publisher.h>
 #include <vector>
 
@@ -98,6 +99,7 @@ protected:
   double desired_angle_;
   ros::Publisher intermediate_goal_pub_;
   ros::Publisher articulation_points_pub_;
+  ros::Publisher intermediate_goal_tolerance_pub_;
 };
 
 }  // namespace mir_dwb_critics

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -87,6 +87,7 @@ protected:
   double articulation_angle_threshold_;
   double heading_scale_;
   bool enforce_forward_dot_;
+  bool always_target_articulations_;
 
   unsigned int last_progress_index_;
   bool holding_goal_;

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -69,7 +69,8 @@ protected:
                    unsigned int& y, double& desired_angle);
 
   unsigned int getGoalIndex(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
-                            unsigned int last_valid_index, double& desired_angle, bool& has_forward_direction) const;
+                            unsigned int last_valid_index, bool plan_tail_is_final_goal, double& desired_angle,
+                            bool& has_forward_direction) const;
 
   bool findNextArticulation(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
                             unsigned int end_index, unsigned int last_valid_index, unsigned int& articulation_index,

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -78,6 +78,9 @@ protected:
   bool computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,
                             double& angle) const;
 
+  bool isPoseReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
+                     double goal_yaw, double xy_tolerance, double yaw_tolerance) const;
+
   bool isGoalReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
                      double goal_yaw) const;
 

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -88,6 +88,7 @@ protected:
   double heading_scale_;
   bool enforce_forward_dot_;
   bool always_target_articulations_;
+  bool initial_alignment_done_;
 
   unsigned int last_progress_index_;
   bool holding_goal_;

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -35,7 +35,13 @@
 #define MIR_DWB_CRITICS_PATH_PROGRESS_H_
 
 #include <dwb_critics/map_grid.h>
+#include <ros/publisher.h>
 #include <vector>
+
+namespace geometry_msgs
+{
+struct PoseStamped;
+}
 
 namespace mir_dwb_critics
 {
@@ -63,14 +69,26 @@ protected:
                    unsigned int& y, double& desired_angle);
 
   unsigned int getGoalIndex(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
-                            unsigned int last_valid_index) const;
+                            unsigned int last_valid_index, double& desired_angle, bool& has_forward_direction) const;
+
+  bool computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,
+                            double& angle) const;
+
+  bool isGoalReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
+                     double goal_yaw) const;
 
   double xy_local_goal_tolerance_;
+  double yaw_local_goal_tolerance_;
   double angle_threshold_;
+  double articulation_angle_threshold_;
   double heading_scale_;
+  bool enforce_forward_dot_;
+
+  unsigned int last_progress_index_;
 
   std::vector<geometry_msgs::Pose2D> reached_intermediate_goals_;
   double desired_angle_;
+  ros::Publisher intermediate_goal_pub_;
 };
 
 }  // namespace mir_dwb_critics

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -81,6 +81,7 @@ protected:
   double xy_local_goal_tolerance_;
   double yaw_local_goal_tolerance_;
   double final_goal_yaw_tolerance_;
+  double final_goal_xy_tolerance_;
   double angle_threshold_;
   double articulation_angle_threshold_;
   double heading_scale_;

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -40,6 +40,7 @@
 #include <visualization_msgs/MarkerArray.h>
 #include <ros/publisher.h>
 #include <ros/time.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -65,8 +66,8 @@ public:
   double scoreTrajectory(const dwb_msgs::Trajectory2D& traj) override;
 
 protected:
-  bool getGoalPose(const geometry_msgs::Pose2D& robot_pose, const nav_2d_msgs::Path2D& global_plan, unsigned int& x,
-                   unsigned int& y, double& desired_angle);
+  bool getGoalPose(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& final_goal,
+                   const nav_2d_msgs::Path2D& global_plan, unsigned int& x, unsigned int& y, double& desired_angle);
 
   unsigned int getGoalIndex(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
                             unsigned int last_valid_index, bool plan_tail_is_final_goal, double& desired_angle,
@@ -102,10 +103,11 @@ protected:
   geometry_msgs::Pose2D last_plan_end_pose_;
   std::string last_plan_frame_id_;
   ros::Time last_plan_stamp_;
-  std::vector<geometry_msgs::Pose2D> last_plan_;
+  uint32_t last_plan_seq_;
+  geometry_msgs::Pose2D last_plan_start_pose_;
+  geometry_msgs::Pose2D last_final_goal_pose_;
+  bool have_last_goal_pose_;
 
-  double plan_position_epsilon_;
-  double plan_yaw_epsilon_;
   double plan_alignment_position_tolerance_;
   double plan_alignment_yaw_tolerance_;
 

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -39,6 +39,8 @@
 #include <sensor_msgs/PointCloud.h>
 #include <visualization_msgs/MarkerArray.h>
 #include <ros/publisher.h>
+#include <ros/time.h>
+#include <string>
 #include <vector>
 
 namespace mir_dwb_critics
@@ -89,6 +91,13 @@ protected:
   bool enforce_forward_dot_;
   bool always_target_articulations_;
   bool initial_alignment_done_;
+
+  // Plan change detection to reset internal state on new global plans
+  bool have_last_plan_;
+  size_t last_plan_size_;
+  geometry_msgs::Pose2D last_plan_end_pose_;
+  std::string last_plan_frame_id_;
+  ros::Time last_plan_stamp_;
 
   unsigned int last_progress_index_;
   bool holding_goal_;

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -35,13 +35,9 @@
 #define MIR_DWB_CRITICS_PATH_PROGRESS_H_
 
 #include <dwb_critics/map_grid.h>
+#include <geometry_msgs/PoseStamped.h>
 #include <ros/publisher.h>
 #include <vector>
-
-namespace geometry_msgs
-{
-struct PoseStamped;
-}
 
 namespace mir_dwb_critics
 {

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -36,6 +36,7 @@
 
 #include <dwb_critics/map_grid.h>
 #include <geometry_msgs/PoseStamped.h>
+#include <sensor_msgs/PointCloud.h>
 #include <ros/publisher.h>
 #include <vector>
 
@@ -95,6 +96,7 @@ protected:
   std::vector<geometry_msgs::Pose2D> reached_intermediate_goals_;
   double desired_angle_;
   ros::Publisher intermediate_goal_pub_;
+  ros::Publisher articulation_points_pub_;
 };
 
 }  // namespace mir_dwb_critics

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -67,6 +67,10 @@ protected:
   unsigned int getGoalIndex(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
                             unsigned int last_valid_index, double& desired_angle, bool& has_forward_direction) const;
 
+  bool findNextArticulation(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
+                            unsigned int end_index, unsigned int last_valid_index, unsigned int& articulation_index,
+                            double& articulation_yaw, bool& has_forward_direction) const;
+
   bool computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,
                             double& angle) const;
 

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -75,12 +75,18 @@ protected:
 
   double xy_local_goal_tolerance_;
   double yaw_local_goal_tolerance_;
+  double final_goal_yaw_tolerance_;
   double angle_threshold_;
   double articulation_angle_threshold_;
   double heading_scale_;
   bool enforce_forward_dot_;
 
   unsigned int last_progress_index_;
+  bool holding_goal_;
+  unsigned int held_goal_index_;
+  geometry_msgs::Pose2D held_goal_pose_;
+  double hold_position_epsilon_;
+  double hold_yaw_epsilon_;
 
   std::vector<geometry_msgs::Pose2D> reached_intermediate_goals_;
   double desired_angle_;

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -102,6 +102,8 @@ protected:
 
   double plan_position_epsilon_;
   double plan_yaw_epsilon_;
+  double plan_alignment_position_tolerance_;
+  double plan_alignment_yaw_tolerance_;
 
   unsigned int last_progress_index_;
   bool holding_goal_;

--- a/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
+++ b/mir_dwb_critics/include/mir_dwb_critics/path_progress.h
@@ -98,6 +98,10 @@ protected:
   geometry_msgs::Pose2D last_plan_end_pose_;
   std::string last_plan_frame_id_;
   ros::Time last_plan_stamp_;
+  std::vector<geometry_msgs::Pose2D> last_plan_;
+
+  double plan_position_epsilon_;
+  double plan_yaw_epsilon_;
 
   unsigned int last_progress_index_;
   bool holding_goal_;

--- a/mir_dwb_critics/src/path_follower.cpp
+++ b/mir_dwb_critics/src/path_follower.cpp
@@ -1,0 +1,1339 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, DFKI GmbH
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <mir_dwb_critics/path_follower.h>
+#include <angles/angles.h>
+#include <nav_grid/coordinate_conversion.h>
+#include <pluginlib/class_list_macros.h>
+#include <nav_2d_utils/path_ops.h>
+#include <sensor_msgs/PointCloud.h>
+#include <visualization_msgs/MarkerArray.h>
+#include <ros/node_handle.h>
+#include <ros/time.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace mir_dwb_critics
+{
+bool PathFollowerCritic::prepare(const geometry_msgs::Pose2D& pose, const nav_2d_msgs::Twist2D& vel,
+                                 const geometry_msgs::Pose2D& goal, const nav_2d_msgs::Path2D& global_plan)
+{
+  dwb_critics::MapGridCritic::reset();
+
+  unsigned int local_goal_x, local_goal_y;
+  if (!getGoalPose(pose, goal, global_plan, local_goal_x, local_goal_y, desired_angle_))
+  {
+    return false;
+  }
+
+  // Enqueue just the last pose
+  cell_values_.setValue(local_goal_x, local_goal_y, 0.0);
+  queue_->enqueueCell(local_goal_x, local_goal_y);
+
+  propogateManhattanDistances();
+
+  return true;
+}
+
+void PathFollowerCritic::onInit()
+{
+  dwb_critics::MapGridCritic::onInit();
+  critic_nh_.param("xy_local_goal_tolerance", xy_local_goal_tolerance_, 0.20);
+  critic_nh_.param("yaw_local_goal_tolerance", yaw_local_goal_tolerance_, 0.15);
+  ros::NodeHandle private_nh("~");
+  if (!private_nh.getParam("yaw_goal_tolerance", final_goal_yaw_tolerance_))
+  {
+    critic_nh_.param("yaw_goal_tolerance", final_goal_yaw_tolerance_, yaw_local_goal_tolerance_);
+  }
+  if (!private_nh.getParam("xy_goal_tolerance", final_goal_xy_tolerance_))
+  {
+    critic_nh_.param("xy_goal_tolerance", final_goal_xy_tolerance_, xy_local_goal_tolerance_);
+  }
+  critic_nh_.param("angle_threshold", angle_threshold_, M_PI_4);
+  critic_nh_.param("articulation_angle_threshold", articulation_angle_threshold_, 1.3089969389957472);
+  critic_nh_.param("heading_scale", heading_scale_, 1.0);
+  critic_nh_.param("enforce_forward_dot", enforce_forward_dot_, true);
+  critic_nh_.param("always_target_articulations", always_target_articulations_, true);
+  initial_alignment_done_ = false;
+
+  intermediate_goal_pub_ = critic_nh_.advertise<geometry_msgs::PoseStamped>("intermediate_goal", 1);
+  articulation_points_pub_ = critic_nh_.advertise<sensor_msgs::PointCloud>("articulation_points", 1);
+  intermediate_goal_tolerance_pub_ =
+      critic_nh_.advertise<visualization_msgs::MarkerArray>("intermediate_goal_tolerance", 1);
+
+  articulation_angle_threshold_ = std::max(articulation_angle_threshold_, angle_threshold_);
+
+  // divide heading scale by position scale because the sum will be multiplied by scale again
+  heading_scale_ /= getScale();
+  last_progress_index_ = 0;
+  reached_intermediate_goals_.clear();
+  holding_goal_ = false;
+  held_goal_index_ = 0;
+  held_goal_pose_.x = 0.0;
+  held_goal_pose_.y = 0.0;
+  held_goal_pose_.theta = 0.0;
+  hold_position_epsilon_ = 1e-6;
+  hold_yaw_epsilon_ = 1e-6;
+  final_goal_yaw_tolerance_ = std::max(final_goal_yaw_tolerance_, 1e-6);
+  final_goal_xy_tolerance_ = std::max(final_goal_xy_tolerance_, 0.0);
+  have_last_plan_ = false;
+  last_plan_size_ = 0;
+  last_plan_end_pose_.x = 0.0;
+  last_plan_end_pose_.y = 0.0;
+  last_plan_end_pose_.theta = 0.0;
+  last_plan_frame_id_.clear();
+  last_plan_stamp_ = ros::Time(0);
+  last_plan_seq_ = 0u;
+  last_plan_start_pose_.x = 0.0;
+  last_plan_start_pose_.y = 0.0;
+  last_plan_start_pose_.theta = 0.0;
+  last_final_goal_pose_.x = 0.0;
+  last_final_goal_pose_.y = 0.0;
+  last_final_goal_pose_.theta = 0.0;
+  have_last_goal_pose_ = false;
+  critic_nh_.param("plan_alignment_position_tolerance", plan_alignment_position_tolerance_, 0.15);
+  critic_nh_.param("plan_alignment_yaw_tolerance", plan_alignment_yaw_tolerance_, 3.14159265358979323846);
+}
+
+void PathFollowerCritic::reset()
+{
+  reached_intermediate_goals_.clear();
+  last_progress_index_ = 0;
+  holding_goal_ = false;
+  held_goal_index_ = 0;
+  held_goal_pose_.x = 0.0;
+  held_goal_pose_.y = 0.0;
+  held_goal_pose_.theta = 0.0;
+  initial_alignment_done_ = false;
+  have_last_plan_ = false;
+  last_plan_size_ = 0;
+  last_plan_end_pose_.x = 0.0;
+  last_plan_end_pose_.y = 0.0;
+  last_plan_end_pose_.theta = 0.0;
+  last_plan_frame_id_.clear();
+  last_plan_stamp_ = ros::Time(0);
+  last_plan_seq_ = 0u;
+  last_plan_start_pose_.x = 0.0;
+  last_plan_start_pose_.y = 0.0;
+  last_plan_start_pose_.theta = 0.0;
+  last_final_goal_pose_.x = 0.0;
+  last_final_goal_pose_.y = 0.0;
+  last_final_goal_pose_.theta = 0.0;
+  have_last_goal_pose_ = false;
+}
+
+double PathFollowerCritic::scoreTrajectory(const dwb_msgs::Trajectory2D& traj)
+{
+  double position_score = MapGridCritic::scoreTrajectory(traj);
+  double heading_diff = fabs(angles::shortest_angular_distance(traj.poses.back().theta, desired_angle_));
+  double heading_score = heading_diff * heading_diff;
+
+  return position_score + heading_scale_ * heading_score;
+}
+
+bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& final_goal,
+                                     const nav_2d_msgs::Path2D& global_plan, unsigned int& x, unsigned int& y,
+                                     double& desired_angle)
+{
+  const nav_core2::Costmap& costmap = *costmap_;
+  const nav_grid::NavGridInfo& info = costmap.getInfo();
+
+  if (global_plan.poses.empty())
+  {
+    ROS_ERROR_NAMED("PathFollowerCritic", "The global plan was empty.");
+    return false;
+  }
+
+  std::vector<geometry_msgs::Pose2D> plan = nav_2d_utils::adjustPlanResolution(global_plan, info.resolution).poses;
+
+  auto posesDiffer = [&](const geometry_msgs::Pose2D& a, const geometry_msgs::Pose2D& b, double position_tolerance,
+                         double yaw_tolerance) {
+    double dx = a.x - b.x;
+    double dy = a.y - b.y;
+    double distance = hypot(dx, dy);
+    if (distance > position_tolerance)
+    {
+      return true;
+    }
+
+    double yaw_error = fabs(angles::shortest_angular_distance(a.theta, b.theta));
+    return yaw_error > yaw_tolerance;
+  };
+
+  if (plan.empty())
+  {
+    ROS_ERROR_NAMED("PathFollowerCritic", "The adjusted global plan was empty.");
+    return false;
+  }
+
+  auto planPoseMatchesFinalGoal = [&](const geometry_msgs::Pose2D& plan_pose) {
+    return !posesDiffer(plan_pose, final_goal, plan_alignment_position_tolerance_, plan_alignment_yaw_tolerance_);
+  };
+
+  bool final_goal_in_plan_window = planPoseMatchesFinalGoal(plan.back());
+
+  auto matchPoseToPlanIndex = [&](const geometry_msgs::Pose2D& pose, unsigned int& index_out) {
+    bool found = false;
+    double best_distance = std::numeric_limits<double>::infinity();
+
+    for (unsigned int idx = 0; idx < plan.size(); ++idx)
+    {
+      double dx = plan[idx].x - pose.x;
+      double dy = plan[idx].y - pose.y;
+      double distance = hypot(dx, dy);
+      if (distance > plan_alignment_position_tolerance_)
+      {
+        continue;
+      }
+
+      double yaw_error = fabs(angles::shortest_angular_distance(plan[idx].theta, pose.theta));
+      if (yaw_error > plan_alignment_yaw_tolerance_)
+      {
+        continue;
+      }
+
+      if (distance < best_distance)
+      {
+        best_distance = distance;
+        index_out = idx;
+        found = true;
+      }
+    }
+
+    return found;
+  };
+
+  // Reset state if a new global plan arrives (detected via metadata changes or major window shifts)
+  bool plan_changed = false;
+  geometry_msgs::Pose2D plan_start_pose = plan.front();
+
+  auto headerStampChanged = [&]() {
+    if (last_plan_stamp_.isZero() || global_plan.header.stamp.isZero())
+    {
+      return false;
+    }
+    return last_plan_stamp_ != global_plan.header.stamp;
+  };
+
+  auto headerSeqChanged = [&]() {
+    if (!have_last_plan_)
+    {
+      return false;
+    }
+    return last_plan_seq_ != global_plan.header.seq;
+  };
+
+  auto goalPoseChanged = [&]() {
+    if (!have_last_goal_pose_)
+    {
+      return true;
+    }
+    return posesDiffer(final_goal, last_final_goal_pose_, plan_alignment_position_tolerance_,
+                       plan_alignment_yaw_tolerance_);
+  };
+
+  auto planStartChanged = [&]() {
+    if (!have_last_plan_)
+    {
+      return true;
+    }
+    // Allow the cropped window to slide by a generous distance without counting as a full plan change.
+    double position_tolerance = std::max(plan_alignment_position_tolerance_ * 4.0, plan_alignment_position_tolerance_);
+    return posesDiffer(plan_start_pose, last_plan_start_pose_, position_tolerance, plan_alignment_yaw_tolerance_);
+  };
+
+  if (!have_last_plan_ || global_plan.header.frame_id != last_plan_frame_id_ || headerStampChanged() ||
+      headerSeqChanged() ||
+      goalPoseChanged())
+  {
+    plan_changed = true;
+  }
+  else if (planStartChanged())
+  {
+    plan_changed = true;
+  }
+
+  if (plan_changed)
+  {
+    bool state_preserved = false;
+    bool progress_match_found = false;
+    unsigned int restored_progress_index = 0u;
+    std::vector<std::pair<unsigned int, geometry_msgs::Pose2D>> preserved_reached;
+    preserved_reached.reserve(reached_intermediate_goals_.size());
+
+    unsigned int previous_progress_index = last_progress_index_;
+
+    for (const auto& reached_pose : reached_intermediate_goals_)
+    {
+      unsigned int matched_index = 0u;
+      if (matchPoseToPlanIndex(reached_pose, matched_index))
+      {
+        geometry_msgs::Pose2D preserved_pose = reached_pose;
+        preserved_pose.x = plan[matched_index].x;
+        preserved_pose.y = plan[matched_index].y;
+        preserved_reached.emplace_back(matched_index, preserved_pose);
+        state_preserved = true;
+        progress_match_found = true;
+        restored_progress_index = std::max(restored_progress_index, matched_index);
+      }
+    }
+
+    unsigned int held_match_index = 0u;
+    if (holding_goal_)
+    {
+      if (matchPoseToPlanIndex(held_goal_pose_, held_match_index))
+      {
+        state_preserved = true;
+        held_goal_index_ = held_match_index;
+        held_goal_pose_.x = plan[held_match_index].x;
+        held_goal_pose_.y = plan[held_match_index].y;
+      }
+      else
+      {
+        holding_goal_ = false;
+        held_goal_index_ = 0u;
+        held_goal_pose_.x = 0.0;
+        held_goal_pose_.y = 0.0;
+        held_goal_pose_.theta = 0.0;
+      }
+    }
+
+    unsigned int robot_match_index = 0u;
+    if (matchPoseToPlanIndex(robot_pose, robot_match_index))
+    {
+      state_preserved = true;
+
+      double match_goal_yaw = plan[robot_match_index].theta;
+      if (!computeOutgoingAngle(plan, robot_match_index, match_goal_yaw))
+      {
+        match_goal_yaw = plan[robot_match_index].theta;
+      }
+
+      bool match_is_final_index = ((robot_match_index + 1u) >= plan.size()) && final_goal_in_plan_window;
+      double match_yaw_tolerance = match_is_final_index ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
+      double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, match_goal_yaw));
+
+      if (yaw_error <= match_yaw_tolerance)
+      {
+        progress_match_found = true;
+        restored_progress_index = std::max(restored_progress_index, robot_match_index);
+      }
+      else
+      {
+        ROS_DEBUG_NAMED("PathFollowerCritic",
+                        "Robot pose matched plan index %u but yaw error %.3f rad exceeds tolerance %.3f."
+                        " Preserving state without increasing progress.",
+                        robot_match_index, yaw_error, match_yaw_tolerance);
+      }
+    }
+
+    if (state_preserved)
+    {
+      if (progress_match_found)
+      {
+        std::sort(preserved_reached.begin(), preserved_reached.end(),
+                  [](const std::pair<unsigned int, geometry_msgs::Pose2D>& lhs,
+                     const std::pair<unsigned int, geometry_msgs::Pose2D>& rhs) {
+                    return lhs.first < rhs.first;
+                  });
+        reached_intermediate_goals_.clear();
+        reached_intermediate_goals_.reserve(preserved_reached.size());
+        for (const auto& entry : preserved_reached)
+        {
+          reached_intermediate_goals_.push_back(entry.second);
+        }
+        unsigned int plan_last_index = plan.empty() ? 0u : static_cast<unsigned int>(plan.size() - 1);
+        last_progress_index_ = std::min(restored_progress_index, plan_last_index);
+      }
+      else
+      {
+        reached_intermediate_goals_.clear();
+        unsigned int plan_last_index = plan.empty() ? 0u : static_cast<unsigned int>(plan.size() - 1);
+        last_progress_index_ = std::min(previous_progress_index, plan_last_index);
+      }
+    }
+    else
+    {
+      reached_intermediate_goals_.clear();
+      last_progress_index_ = 0u;
+      holding_goal_ = false;
+      held_goal_index_ = 0u;
+      held_goal_pose_.x = 0.0;
+      held_goal_pose_.y = 0.0;
+      held_goal_pose_.theta = 0.0;
+      initial_alignment_done_ = false;
+    }
+
+    have_last_plan_ = true;
+  }
+
+  last_plan_size_ = plan.size();
+  last_plan_end_pose_ = plan.back();
+  last_plan_frame_id_ = global_plan.header.frame_id;
+  last_plan_stamp_ = global_plan.header.stamp;
+  last_plan_seq_ = global_plan.header.seq;
+  last_plan_start_pose_ = plan_start_pose;
+  last_final_goal_pose_ = final_goal;
+  have_last_goal_pose_ = true;
+
+
+  unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
+
+  if (initial_alignment_done_ && plan.size() > 1 && last_progress_index_ > 0)
+  {
+    unsigned int prune_limit = std::min(last_progress_index_, plan_last_index);
+    if (prune_limit > 0)
+    {
+      plan.erase(plan.begin(), plan.begin() + prune_limit);
+      last_progress_index_ = last_progress_index_ >= prune_limit ? last_progress_index_ - prune_limit : 0;
+      plan_last_index = static_cast<unsigned int>(plan.size() - 1);
+
+      if (holding_goal_)
+      {
+        if (held_goal_index_ < prune_limit)
+        {
+          holding_goal_ = false;
+          held_goal_index_ = 0;
+        }
+        else
+        {
+          held_goal_index_ -= prune_limit;
+        }
+      }
+    }
+  }
+
+  if (holding_goal_ && held_goal_index_ >= plan.size())
+  {
+    ROS_DEBUG_NAMED("PathFollowerCritic", "Held goal index %u is out of range for current plan of size %zu. Releasing hold.",
+                    held_goal_index_, plan.size());
+    holding_goal_ = false;
+    held_goal_index_ = 0;
+  }
+
+  // find the "start pose", i.e. the pose on the plan closest to the robot that is also on the local map
+  unsigned int start_index = 0;
+  double distance_to_start = std::numeric_limits<double>::infinity();
+  bool started_path = false;
+  for (unsigned int i = 0; i < plan.size(); i++)
+  {
+    double g_x = plan[i].x;
+    double g_y = plan[i].y;
+    unsigned int map_x, map_y;
+    if (worldToGridBounded(info, g_x, g_y, map_x, map_y) && costmap(map_x, map_y) != nav_core2::Costmap::NO_INFORMATION)
+    {
+      // Still on the costmap. Continue.
+      double distance = nav_2d_utils::poseDistance(plan[i], robot_pose);
+      if (distance_to_start > distance)
+      {
+        start_index = i;
+        distance_to_start = distance;
+        started_path = true;
+      }
+      else
+      {
+        // Plan is going away from the robot again. It's possible that it comes back and we would find a pose that's
+        // even closer to the robot, but then we would skip over parts of the plan.
+        break;
+      }
+    }
+    else if (started_path)
+    {
+      // Off the costmap after being on the costmap.
+      break;
+    }
+    // else, we have not yet found a point on the costmap, so we just continue
+  }
+
+  if (!started_path)
+  {
+    ROS_ERROR_NAMED("PathFollowerCritic", "None of the points of the global plan were in the local costmap.");
+    return false;
+  }
+
+  // find the "last valid pose", i.e. the last pose on the plan after the start pose that is still on the local map
+  unsigned int last_valid_index = start_index;
+  for (unsigned int i = start_index + 1; i < plan.size(); i++)
+  {
+    double g_x = plan[i].x;
+    double g_y = plan[i].y;
+    unsigned int map_x, map_y;
+    if (worldToGridBounded(info, g_x, g_y, map_x, map_y) && costmap(map_x, map_y) != nav_core2::Costmap::NO_INFORMATION)
+    {
+      // Still on the costmap. Continue.
+      last_valid_index = i;
+    }
+    else
+    {
+      // Off the costmap after being on the costmap.
+      break;
+    }
+  }
+
+  auto collectArticulationIndices = [&](unsigned int scan_start, unsigned int scan_end) {
+    std::vector<unsigned int> articulation_indices;
+    if (plan.size() < 2)
+    {
+      return articulation_indices;
+    }
+
+    const double epsilon = 1e-9;
+    unsigned int clamped_start = std::max(scan_start, 1u);
+    unsigned int clamped_end = std::min(scan_end, plan_last_index);
+    if (clamped_start > clamped_end)
+    {
+      return articulation_indices;
+    }
+
+    double previous_segment_angle = 0.0;
+    bool previous_segment_angle_set = false;
+    unsigned int previous_segment_end_index = 0u;
+
+    for (unsigned int i = clamped_start; i <= clamped_end; ++i)
+    {
+      double direction_x = plan[i].x - plan[i - 1].x;
+      double direction_y = plan[i].y - plan[i - 1].y;
+      double length = hypot(direction_x, direction_y);
+      if (length < epsilon)
+      {
+        continue;
+      }
+
+      double current_angle = atan2(direction_y, direction_x);
+      if (previous_segment_angle_set)
+      {
+        double articulation_angle =
+            fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
+        if (articulation_angle >= articulation_angle_threshold_)
+        {
+          if (articulation_indices.empty() || articulation_indices.back() != previous_segment_end_index)
+          {
+            articulation_indices.push_back(previous_segment_end_index);
+          }
+        }
+      }
+
+      previous_segment_angle = current_angle;
+      previous_segment_angle_set = true;
+      previous_segment_end_index = i;
+    }
+
+    return articulation_indices;
+  };
+
+  auto publishArticulationPointCloud = [&](const std::vector<unsigned int>& articulation_indices) {
+    if (!articulation_points_pub_)
+    {
+      return;
+    }
+
+    sensor_msgs::PointCloud cloud_msg;
+    cloud_msg.header = global_plan.header;
+    cloud_msg.header.stamp = ros::Time::now();
+    cloud_msg.points.reserve(articulation_indices.size());
+
+    for (unsigned int index : articulation_indices)
+    {
+      if (index >= plan.size())
+      {
+        continue;
+      }
+
+      geometry_msgs::Point32 point;
+      point.x = plan[index].x;
+      point.y = plan[index].y;
+      point.z = 0.0;
+      cloud_msg.points.push_back(point);
+    }
+
+    articulation_points_pub_.publish(cloud_msg);
+  };
+
+  auto publishIntermediateGoal = [&](const geometry_msgs::Pose2D& goal_pose, double goal_yaw) {
+    if (!intermediate_goal_pub_)
+    {
+      return;
+    }
+    geometry_msgs::PoseStamped goal_msg;
+    goal_msg.header = global_plan.header;
+    goal_msg.header.stamp = ros::Time::now();
+    goal_msg.pose.position.x = goal_pose.x;
+    goal_msg.pose.position.y = goal_pose.y;
+    goal_msg.pose.position.z = 0.0;
+    tf2::Quaternion q;
+    q.setRPY(0.0, 0.0, goal_yaw);
+    goal_msg.pose.orientation.x = q.x();
+    goal_msg.pose.orientation.y = q.y();
+    goal_msg.pose.orientation.z = q.z();
+    goal_msg.pose.orientation.w = q.w();
+    intermediate_goal_pub_.publish(goal_msg);
+
+    if (intermediate_goal_tolerance_pub_)
+    {
+      visualization_msgs::MarkerArray marker_array;
+      visualization_msgs::Marker marker;
+      marker.header = goal_msg.header;
+      marker.header.stamp = goal_msg.header.stamp;
+      marker.ns = "intermediate_goal_tolerance";
+      marker.id = 0;
+      marker.type = visualization_msgs::Marker::SPHERE;
+      marker.action = visualization_msgs::Marker::ADD;
+      marker.pose.position = goal_msg.pose.position;
+      marker.pose.orientation.x = 0.0;
+      marker.pose.orientation.y = 0.0;
+      marker.pose.orientation.z = 0.0;
+      marker.pose.orientation.w = 1.0;
+      double diameter = std::max(2.0 * xy_local_goal_tolerance_, 1e-6);
+      marker.scale.x = diameter;
+      marker.scale.y = diameter;
+      marker.scale.z = diameter;
+      marker.color.r = 0.2f;
+      marker.color.g = 0.8f;
+      marker.color.b = 0.4f;
+      marker.color.a = 0.35f;
+      marker.lifetime = ros::Duration(0.0);
+      marker_array.markers.push_back(marker);
+      intermediate_goal_tolerance_pub_.publish(marker_array);
+    }
+  };
+
+  if (!initial_alignment_done_)
+  {
+    double desired_initial_yaw = plan.front().theta;
+    if (!plan.empty())
+    {
+      double outgoing_angle = desired_initial_yaw;
+      if (computeOutgoingAngle(plan, 0u, outgoing_angle))
+      {
+        desired_initial_yaw = outgoing_angle;
+      }
+    }
+
+    double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, desired_initial_yaw));
+    if (yaw_error >= yaw_local_goal_tolerance_)
+    {
+      unsigned int rx = 0;
+      unsigned int ry = 0;
+      if (worldToGridBounded(info, robot_pose.x, robot_pose.y, rx, ry))
+      {
+        x = rx;
+        y = ry;
+        desired_angle = desired_initial_yaw;
+        held_goal_pose_.x = robot_pose.x;
+        held_goal_pose_.y = robot_pose.y;
+        held_goal_pose_.theta = desired_initial_yaw;
+        held_goal_index_ = 0;
+        holding_goal_ = true;
+        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
+        ROS_DEBUG_NAMED("PathFollowerCritic",
+                        "Initial alignment: rotate in place to yaw %.3f rad at robot pose (x: %.3f, y: %.3f)",
+                        held_goal_pose_.theta, held_goal_pose_.x, held_goal_pose_.y);
+        return true;
+      }
+    }
+
+    initial_alignment_done_ = true;
+  }
+
+  std::vector<unsigned int> articulation_indices = collectArticulationIndices(1u, plan_last_index);
+  publishArticulationPointCloud(articulation_indices);
+
+  if (holding_goal_)
+  {
+    unsigned int held_x = 0;
+    unsigned int held_y = 0;
+    bool held_in_costmap = worldToGridBounded(info, held_goal_pose_.x, held_goal_pose_.y, held_x, held_y);
+
+    if (!held_in_costmap)
+    {
+      ROS_WARN_NAMED("PathFollowerCritic",
+                     "Held goal (index %u) is outside the local costmap. Releasing hold to search for a new goal.",
+                     held_goal_index_);
+      holding_goal_ = false;
+      held_goal_index_ = 0;
+    }
+    else
+    {
+      double held_xy_tolerance =
+          (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ? final_goal_xy_tolerance_ :
+                                                                             xy_local_goal_tolerance_;
+      double held_yaw_tolerance =
+          (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ? final_goal_yaw_tolerance_ :
+                                                                              yaw_local_goal_tolerance_;
+
+      double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, held_goal_pose_.theta));
+      if (yaw_error >= held_yaw_tolerance)
+      {
+        x = held_x;
+        y = held_y;
+        desired_angle = held_goal_pose_.theta;
+        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
+        ROS_DEBUG_NAMED("PathFollowerCritic", "Holding goal index %u due to yaw error %.3f rad (threshold %.3f)",
+                        held_goal_index_, yaw_error, held_yaw_tolerance);
+        return true;
+      }
+
+      if (!isPoseReached(robot_pose, held_goal_pose_, held_goal_pose_.theta, held_xy_tolerance, held_yaw_tolerance))
+      {
+        x = held_x;
+        y = held_y;
+        desired_angle = held_goal_pose_.theta;
+        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
+        ROS_DEBUG_NAMED("PathFollowerCritic",
+                        "Holding goal index %u until full pose tolerance satisfied (XY + yaw)", held_goal_index_);
+        return true;
+      }
+
+      last_progress_index_ = std::max(last_progress_index_, held_goal_index_);
+      geometry_msgs::Pose2D reached_pose = held_goal_pose_;
+      if (reached_intermediate_goals_.empty() ||
+          nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
+          fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) > 1e-6)
+      {
+        reached_intermediate_goals_.push_back(reached_pose);
+      }
+      ROS_DEBUG_NAMED("PathFollowerCritic",
+                      "Reached held intermediate goal index %u while respecting pose tolerances. last_progress_index_: %u",
+                      held_goal_index_, last_progress_index_);
+      holding_goal_ = false;
+    }
+  }
+
+  // Constrain the search range to enforce monotonic progress with the updated bookkeeping.
+  last_progress_index_ = std::min(last_progress_index_, plan_last_index);
+
+  unsigned int search_start_index = std::max(start_index, last_progress_index_);
+  search_start_index = std::min(search_start_index, last_valid_index);
+
+  if (holding_goal_ && held_goal_index_ >= last_progress_index_)
+  {
+    search_start_index = std::min(search_start_index, held_goal_index_);
+  }
+
+  unsigned int articulation_scan_start = 0u;
+  if (plan_last_index >= 1)
+  {
+    unsigned int next_index = last_progress_index_ < plan_last_index ? last_progress_index_ + 1 : plan_last_index;
+    articulation_scan_start = std::max(next_index, 1u);
+  }
+  else
+  {
+    articulation_scan_start = plan_last_index;
+  }
+
+  auto articulationSearchStart = [&](unsigned int candidate_start) {
+    return std::max({candidate_start, articulation_scan_start, 1u});
+  };
+
+  unsigned int goal_index = search_start_index;
+  double goal_yaw = plan[goal_index].theta;
+  bool has_forward_direction = false;
+  bool found_goal = false;
+  bool forced_skipped_articulation = false;
+  unsigned int next_articulation_index = 0;
+  double next_articulation_yaw = 0.0;
+  bool next_articulation_has_forward = false;
+  bool has_next_articulation = false;
+
+  if (initial_alignment_done_ && !articulation_indices.empty())
+  {
+    unsigned int articulation_window_start = std::max(search_start_index, last_progress_index_ + 1);
+    unsigned int articulation_window_end = last_valid_index;
+
+    for (unsigned int idx : articulation_indices)
+    {
+      if (idx < articulation_window_start || idx > articulation_window_end)
+      {
+        continue;
+      }
+
+      double articulation_yaw = plan[idx].theta;
+      bool articulation_has_forward = computeOutgoingAngle(plan, idx, articulation_yaw);
+      double articulation_goal_yaw = articulation_has_forward ? articulation_yaw : plan[idx].theta;
+
+      double articulation_xy_tolerance =
+          (final_goal_in_plan_window && idx == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
+      double articulation_yaw_tolerance =
+          (final_goal_in_plan_window && idx == plan_last_index) ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
+
+      if (isPoseReached(robot_pose, plan[idx], articulation_goal_yaw, articulation_xy_tolerance,
+                        articulation_yaw_tolerance))
+      {
+        last_progress_index_ = std::max(last_progress_index_, idx);
+        geometry_msgs::Pose2D reached_pose = plan[idx];
+        reached_pose.theta = articulation_goal_yaw;
+        if (reached_intermediate_goals_.empty() ||
+            nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
+            fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) >
+                1e-6)
+        {
+          reached_intermediate_goals_.push_back(reached_pose);
+        }
+        continue;
+      }
+
+      next_articulation_index = idx;
+      next_articulation_yaw = articulation_goal_yaw;
+      next_articulation_has_forward = articulation_has_forward;
+      has_next_articulation = true;
+      break;
+    }
+  }
+
+  if (!found_goal && initial_alignment_done_ && search_start_index > last_progress_index_ + 1 &&
+      !articulation_indices.empty())
+  {
+    unsigned int articulation_lower_bound = std::max(last_progress_index_ + 1, 1u);
+    unsigned int articulation_upper_bound = std::min(search_start_index - 1, last_valid_index);
+
+    if (articulation_lower_bound <= articulation_upper_bound)
+    {
+      auto articulation_it = std::find_if(articulation_indices.begin(), articulation_indices.end(),
+                                          [&](unsigned int index) {
+                                            return index >= articulation_lower_bound && index <= articulation_upper_bound;
+                                          });
+
+      if (articulation_it != articulation_indices.end())
+      {
+        goal_index = *articulation_it;
+        has_forward_direction = computeOutgoingAngle(plan, goal_index, goal_yaw);
+        if (!has_forward_direction)
+        {
+          goal_yaw = plan[goal_index].theta;
+        }
+
+        if (enforce_forward_dot_ && has_forward_direction)
+        {
+          double to_goal_x = plan[goal_index].x - robot_pose.x;
+          double to_goal_y = plan[goal_index].y - robot_pose.y;
+          double dot = to_goal_x * std::cos(goal_yaw) + to_goal_y * std::sin(goal_yaw);
+          if (dot < 0.0)
+          {
+            ROS_WARN_NAMED("PathFollowerCritic",
+                           "Forcing skipped articulation index %u despite backward dot product %.3f due to policy.",
+                           goal_index, dot);
+          }
+        }
+
+        forced_skipped_articulation = true;
+        found_goal = true;
+        ROS_DEBUG_NAMED("PathFollowerCritic",
+                        "Recovered skipped articulation index %u between progress %u and search start %u.",
+                        goal_index, last_progress_index_, search_start_index);
+      }
+    }
+  }
+
+  unsigned int search_index = search_start_index;
+  while (!forced_skipped_articulation && search_index <= last_valid_index)
+  {
+    double candidate_yaw = goal_yaw;
+    bool candidate_has_forward = false;
+    unsigned int candidate_index =
+        getGoalIndex(plan, search_index, last_valid_index, final_goal_in_plan_window, candidate_yaw, candidate_has_forward);
+
+    bool forced_articulation = false;
+    if (candidate_index > last_progress_index_)
+    {
+      unsigned int articulation_index = 0;
+      double articulation_yaw = candidate_yaw;
+      bool articulation_has_forward = candidate_has_forward;
+      unsigned int articulation_start_index = articulationSearchStart(search_index);
+      if (articulation_start_index <= candidate_index &&
+          findNextArticulation(plan, articulation_start_index, candidate_index, last_valid_index,
+                               articulation_index, articulation_yaw, articulation_has_forward))
+      {
+        candidate_index = articulation_index;
+        candidate_yaw = articulation_yaw;
+        candidate_has_forward = articulation_has_forward;
+        forced_articulation = true;
+      }
+    }
+
+    if (!forced_articulation)
+    {
+      candidate_index = std::max(candidate_index, search_index);
+    }
+
+    if (has_next_articulation && candidate_index >= next_articulation_index)
+    {
+      goal_index = next_articulation_index;
+      goal_yaw = next_articulation_yaw;
+      has_forward_direction = next_articulation_has_forward;
+      found_goal = true;
+      forced_skipped_articulation = true;
+      has_next_articulation = false;
+      ROS_DEBUG_NAMED("PathFollowerCritic",
+                      "Selecting pending articulation index %u reached at candidate %u.", goal_index,
+                      candidate_index);
+      break;
+    }
+
+    double candidate_xy_tolerance =
+        (final_goal_in_plan_window && candidate_index == plan_last_index) ? final_goal_xy_tolerance_ :
+                                                                           xy_local_goal_tolerance_;
+    double candidate_yaw_tolerance =
+        (final_goal_in_plan_window && candidate_index == plan_last_index) ? final_goal_yaw_tolerance_ :
+                                                                            yaw_local_goal_tolerance_;
+
+    if (isPoseReached(robot_pose, plan[candidate_index], candidate_yaw, candidate_xy_tolerance,
+                      candidate_yaw_tolerance))
+    {
+      last_progress_index_ = std::max(last_progress_index_, candidate_index);
+      geometry_msgs::Pose2D reached_pose = plan[candidate_index];
+      reached_pose.theta = candidate_yaw;
+      if (reached_intermediate_goals_.empty() ||
+          nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
+          fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) > 1e-6)
+      {
+        reached_intermediate_goals_.push_back(reached_pose);
+      }
+      ROS_DEBUG_NAMED("PathFollowerCritic",
+                      "Reached intermediate goal index %u. last_progress_index_: %u", candidate_index,
+                      last_progress_index_);
+
+      if (candidate_index >= last_valid_index)
+      {
+        goal_index = candidate_index;
+        goal_yaw = candidate_yaw;
+        has_forward_direction = candidate_has_forward;
+        found_goal = true;
+        break;
+      }
+
+      search_index = candidate_index + 1;
+      continue;
+    }
+
+    if (enforce_forward_dot_ && candidate_has_forward && !forced_articulation)
+    {
+      double to_goal_x = plan[candidate_index].x - robot_pose.x;
+      double to_goal_y = plan[candidate_index].y - robot_pose.y;
+      double dot = to_goal_x * std::cos(candidate_yaw) + to_goal_y * std::sin(candidate_yaw);
+      if (dot < 0.0)
+      {
+        ROS_DEBUG_NAMED("PathFollowerCritic",
+                        "Skipping goal index %u due to backward alignment (dot product %.3f)", candidate_index, dot);
+        if (candidate_index >= last_valid_index)
+        {
+          break;
+        }
+        search_index = candidate_index + 1;
+        continue;
+      }
+    }
+
+    goal_index = candidate_index;
+    goal_yaw = candidate_yaw;
+    has_forward_direction = candidate_has_forward;
+    found_goal = true;
+    break;
+  }
+
+  if (!found_goal)
+  {
+    unsigned int fallback_start = std::min(last_valid_index, search_start_index);
+    goal_index = fallback_start;
+    bool selected_fallback = false;
+
+    for (; goal_index <= last_valid_index; ++goal_index)
+    {
+      has_forward_direction = computeOutgoingAngle(plan, goal_index, goal_yaw);
+      if (has_forward_direction)
+      {
+        if (!enforce_forward_dot_)
+        {
+          selected_fallback = true;
+          break;
+        }
+
+        double to_goal_x = plan[goal_index].x - robot_pose.x;
+        double to_goal_y = plan[goal_index].y - robot_pose.y;
+        double dot = to_goal_x * std::cos(goal_yaw) + to_goal_y * std::sin(goal_yaw);
+        if (dot >= 0.0)
+        {
+          selected_fallback = true;
+          break;
+        }
+        continue;
+      }
+
+      goal_yaw = plan[goal_index].theta;
+      if (!enforce_forward_dot_ || goal_index == last_valid_index)
+      {
+        selected_fallback = true;
+        break;
+      }
+    }
+
+    if (!selected_fallback)
+    {
+      return false;
+    }
+
+    if (has_next_articulation && goal_index >= next_articulation_index)
+    {
+      goal_index = next_articulation_index;
+      goal_yaw = next_articulation_yaw;
+      has_forward_direction = next_articulation_has_forward;
+      has_next_articulation = false;
+      forced_skipped_articulation = true;
+      ROS_DEBUG_NAMED("PathFollowerCritic",
+                      "Fallback switching to pending articulation index %u.", goal_index);
+    }
+
+    if (goal_index > last_progress_index_)
+    {
+      unsigned int articulation_index = 0;
+      double articulation_yaw = goal_yaw;
+      bool articulation_has_forward = has_forward_direction;
+      unsigned int articulation_start_index = articulationSearchStart(search_start_index);
+      if (articulation_start_index <= goal_index &&
+          findNextArticulation(plan, articulation_start_index, goal_index, last_valid_index,
+                               articulation_index, articulation_yaw, articulation_has_forward))
+      {
+        goal_index = articulation_index;
+        goal_yaw = articulation_yaw;
+        has_forward_direction = articulation_has_forward;
+      }
+    }
+  }
+
+  if (final_goal_in_plan_window && plan_last_index <= last_valid_index && goal_index != plan_last_index)
+  {
+    double snap_threshold = final_goal_xy_tolerance_;
+    if (snap_threshold >= 0.0)
+    {
+      double final_dx = plan[plan_last_index].x - plan[goal_index].x;
+      double final_dy = plan[plan_last_index].y - plan[goal_index].y;
+      double distance_to_final = hypot(final_dx, final_dy);
+      if (distance_to_final <= snap_threshold)
+      {
+        ROS_DEBUG_NAMED("PathFollowerCritic",
+                        "Snapping intermediate goal index %u to final goal because distance %.3f <= threshold %.3f",
+                        goal_index, distance_to_final, snap_threshold);
+        goal_index = plan_last_index;
+        goal_yaw = plan[plan_last_index].theta;
+        has_forward_direction = false;
+        forced_skipped_articulation = false;
+        has_next_articulation = false;
+      }
+    }
+  }
+
+  bool pending_articulation = false;
+  if (last_progress_index_ < goal_index)
+  {
+    pending_articulation = std::find(articulation_indices.begin(), articulation_indices.end(), goal_index) !=
+                           articulation_indices.end();
+  }
+
+  // Only consider snapping to the final goal yaw when we have already selected the last path index as goal.
+  // Otherwise, keep following the path even if the final goal is within tolerance.
+  if (!pending_articulation && final_goal_xy_tolerance_ >= 0.0 && final_goal_in_plan_window &&
+      plan_last_index <= last_valid_index && goal_index == plan_last_index)
+  {
+    double final_dx = plan[plan_last_index].x - plan[goal_index].x;
+    double final_dy = plan[plan_last_index].y - plan[goal_index].y;
+    double final_distance = hypot(final_dx, final_dy);
+    if (final_distance <= final_goal_xy_tolerance_)
+    {
+      goal_index = plan_last_index;
+      goal_yaw = plan[plan_last_index].theta;
+      has_forward_direction = false;
+    }
+  }
+
+  ROS_ASSERT(goal_index <= last_valid_index);
+
+  worldToGridBounded(info, plan[goal_index].x, plan[goal_index].y, x, y);
+  desired_angle = goal_yaw;
+
+  bool same_as_held = false;
+  if (holding_goal_)
+  {
+    double position_diff_x = plan[goal_index].x - held_goal_pose_.x;
+    double position_diff_y = plan[goal_index].y - held_goal_pose_.y;
+    double yaw_diff = angles::shortest_angular_distance(goal_yaw, held_goal_pose_.theta);
+    same_as_held = (fabs(position_diff_x) <= hold_position_epsilon_) &&
+                   (fabs(position_diff_y) <= hold_position_epsilon_) &&
+                   (fabs(yaw_diff) <= hold_yaw_epsilon_);
+  }
+
+  if (!same_as_held)
+  {
+    held_goal_pose_ = plan[goal_index];
+    held_goal_pose_.theta = goal_yaw;
+    held_goal_index_ = goal_index;
+  }
+  else
+  {
+    held_goal_pose_.x = plan[goal_index].x;
+    held_goal_pose_.y = plan[goal_index].y;
+    held_goal_pose_.theta = goal_yaw;
+  }
+  holding_goal_ = true;
+
+  ROS_DEBUG_NAMED("PathFollowerCritic",
+                  "Selected goal index %u (x: %.3f, y: %.3f, yaw: %.3f rad). last_progress_index_: %u",
+                  goal_index, plan[goal_index].x, plan[goal_index].y, goal_yaw, last_progress_index_);
+
+  publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
+  return true;
+}
+
+unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
+                                              unsigned int last_valid_index, bool plan_tail_is_final_goal,
+                                              double& desired_angle, bool& has_forward_direction) const
+{
+  if (plan.empty())
+  {
+    desired_angle = 0.0;
+    has_forward_direction = false;
+    return 0;
+  }
+
+  const double epsilon = 1e-9;
+  unsigned int clamped_start = std::min(start_index, static_cast<unsigned int>(plan.size() - 1));
+  unsigned int clamped_last = std::min(last_valid_index, static_cast<unsigned int>(plan.size() - 1));
+
+  if (clamped_start >= clamped_last)
+  {
+    has_forward_direction = computeOutgoingAngle(plan, clamped_start, desired_angle);
+    if (!has_forward_direction)
+    {
+      desired_angle = plan[clamped_start].theta;
+    }
+    return clamped_start;
+  }
+
+  unsigned int goal_index = clamped_start;
+  double base_angle = 0.0;
+  bool base_angle_set = false;
+  double previous_segment_angle = 0.0;
+  bool previous_segment_angle_set = false;
+  unsigned int previous_segment_end_index = clamped_start;
+  double last_valid_segment_angle = 0.0;
+  bool last_valid_segment_angle_set = false;
+
+  for (unsigned int i = clamped_start + 1; i <= clamped_last; ++i)
+  {
+    double direction_x = plan[i].x - plan[i - 1].x;
+    double direction_y = plan[i].y - plan[i - 1].y;
+    double length = hypot(direction_x, direction_y);
+    if (length < epsilon)
+    {
+      continue;
+    }
+
+    double current_angle = atan2(direction_y, direction_x);
+    last_valid_segment_angle = current_angle;
+    last_valid_segment_angle_set = true;
+
+    if (!base_angle_set)
+    {
+      base_angle = current_angle;
+      base_angle_set = true;
+    }
+
+    if (previous_segment_angle_set)
+    {
+      double articulation_angle = fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
+      if (articulation_angle >= articulation_angle_threshold_)
+      {
+        goal_index = previous_segment_end_index;
+        break;
+      }
+    }
+
+    double deviation = fabs(angles::shortest_angular_distance(base_angle, current_angle));
+    if (deviation > angle_threshold_)
+    {
+      break;
+    }
+
+    goal_index = i;
+    previous_segment_angle = current_angle;
+    previous_segment_end_index = i;
+    previous_segment_angle_set = true;
+  }
+
+  has_forward_direction = computeOutgoingAngle(plan, goal_index, desired_angle);
+  if (!has_forward_direction)
+  {
+    if (plan_tail_is_final_goal && goal_index == plan.size() - 1)
+    {
+      desired_angle = plan[goal_index].theta;
+    }
+    else if (previous_segment_angle_set)
+    {
+      desired_angle = previous_segment_angle;
+      has_forward_direction = true;
+    }
+    else if (last_valid_segment_angle_set)
+    {
+      desired_angle = last_valid_segment_angle;
+      has_forward_direction = true;
+    }
+    else
+    {
+      desired_angle = plan[goal_index].theta;
+    }
+  }
+
+  if (plan_tail_is_final_goal && goal_index == plan.size() - 1)
+  {
+    has_forward_direction = false;
+  }
+
+  return goal_index;
+}
+
+bool PathFollowerCritic::findNextArticulation(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
+                                              unsigned int end_index, unsigned int last_valid_index,
+                                              unsigned int& articulation_index, double& articulation_yaw,
+                                              bool& has_forward_direction) const
+{
+  const double epsilon = 1e-9;
+  articulation_index = 0;
+  articulation_yaw = 0.0;
+  has_forward_direction = false;
+
+  if (plan.size() < 2)
+  {
+    return false;
+  }
+
+  unsigned int clamped_end = std::min(end_index, static_cast<unsigned int>(plan.size() - 1));
+  clamped_end = std::min(clamped_end, last_valid_index);
+  if (clamped_end < 1)
+  {
+    return false;
+  }
+
+  unsigned int scan_start = std::max(start_index, 1u);
+  if (scan_start > clamped_end)
+  {
+    return false;
+  }
+
+  double previous_segment_angle = 0.0;
+  bool previous_segment_angle_set = false;
+  unsigned int previous_segment_end_index = 0;
+
+  for (unsigned int i = scan_start; i <= clamped_end; ++i)
+  {
+    double direction_x = plan[i].x - plan[i - 1].x;
+    double direction_y = plan[i].y - plan[i - 1].y;
+    double length = hypot(direction_x, direction_y);
+    if (length < epsilon)
+    {
+      continue;
+    }
+
+    double current_angle = atan2(direction_y, direction_x);
+
+    if (previous_segment_angle_set)
+    {
+      double articulation_angle = fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
+      if (articulation_angle >= articulation_angle_threshold_)
+      {
+        articulation_index = previous_segment_end_index;
+        articulation_yaw = current_angle;
+        has_forward_direction = true;
+        if (!computeOutgoingAngle(plan, articulation_index, articulation_yaw))
+        {
+          has_forward_direction = false;
+          if (articulation_index == plan.size() - 1)
+          {
+            articulation_yaw = plan[articulation_index].theta;
+          }
+        }
+        return true;
+      }
+    }
+
+    previous_segment_angle = current_angle;
+    previous_segment_angle_set = true;
+    previous_segment_end_index = i;
+  }
+
+  return false;
+}
+
+bool PathFollowerCritic::computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,
+                                              double& angle) const
+{
+  const double epsilon = 1e-9;
+  if (plan.empty() || index >= plan.size())
+  {
+    return false;
+  }
+
+  for (unsigned int i = index + 1; i < plan.size(); ++i)
+  {
+    double dx = plan[i].x - plan[index].x;
+    double dy = plan[i].y - plan[index].y;
+    double length = hypot(dx, dy);
+    if (length >= epsilon)
+    {
+      angle = atan2(dy, dx);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool PathFollowerCritic::isPoseReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
+                                       double goal_yaw, double xy_tolerance, double yaw_tolerance) const
+{
+  double distance = nav_2d_utils::poseDistance(goal_pose, robot_pose);
+  double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, goal_yaw));
+
+  return distance < xy_tolerance && yaw_error < yaw_tolerance;
+}
+
+bool PathFollowerCritic::isGoalReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
+                                       double goal_yaw) const
+{
+  return isPoseReached(robot_pose, goal_pose, goal_yaw, xy_local_goal_tolerance_, yaw_local_goal_tolerance_);
+}
+
+}  // namespace mir_dwb_critics
+
+PLUGINLIB_EXPORT_CLASS(mir_dwb_critics::PathFollowerCritic, dwb_local_planner::TrajectoryCritic)

--- a/mir_dwb_critics/src/path_follower.cpp
+++ b/mir_dwb_critics/src/path_follower.cpp
@@ -311,8 +311,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   };
 
   if (!have_last_plan_ || global_plan.header.frame_id != last_plan_frame_id_ || headerStampChanged() ||
-      headerSeqChanged() ||
-      goalPoseChanged())
+      headerSeqChanged() || goalPoseChanged())
   {
     plan_changed = true;
   }
@@ -399,9 +398,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       {
         std::sort(preserved_reached.begin(), preserved_reached.end(),
                   [](const std::pair<unsigned int, geometry_msgs::Pose2D>& lhs,
-                     const std::pair<unsigned int, geometry_msgs::Pose2D>& rhs) {
-                    return lhs.first < rhs.first;
-                  });
+                     const std::pair<unsigned int, geometry_msgs::Pose2D>& rhs) { return lhs.first < rhs.first; });
         reached_intermediate_goals_.clear();
         reached_intermediate_goals_.reserve(preserved_reached.size());
         for (const auto& entry : preserved_reached)
@@ -442,7 +439,6 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   last_final_goal_pose_ = final_goal;
   have_last_goal_pose_ = true;
 
-
   unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
 
   if (initial_alignment_done_ && plan.size() > 1 && last_progress_index_ > 0)
@@ -471,7 +467,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   if (holding_goal_ && held_goal_index_ >= plan.size())
   {
-    ROS_DEBUG_NAMED("PathFollowerCritic", "Held goal index %u is out of range for current plan of size %zu. Releasing hold.",
+    ROS_DEBUG_NAMED("PathFollowerCritic",
+                    "Held goal index %u is out of range for current plan of size %zu. Releasing hold.",
                     held_goal_index_, plan.size());
     holding_goal_ = false;
     held_goal_index_ = 0;
@@ -568,8 +565,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       double current_angle = atan2(direction_y, direction_x);
       if (previous_segment_angle_set)
       {
-        double articulation_angle =
-            fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
+        double articulation_angle = fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
         if (articulation_angle >= articulation_angle_threshold_)
         {
           if (articulation_indices.empty() || articulation_indices.back() != previous_segment_end_index)
@@ -712,12 +708,12 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
     else
     {
-      double held_xy_tolerance =
-          (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ? final_goal_xy_tolerance_ :
-                                                                             xy_local_goal_tolerance_;
-      double held_yaw_tolerance =
-          (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ? final_goal_yaw_tolerance_ :
-                                                                              yaw_local_goal_tolerance_;
+      double held_xy_tolerance = (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ?
+                                     final_goal_xy_tolerance_ :
+                                     xy_local_goal_tolerance_;
+      double held_yaw_tolerance = (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ?
+                                      final_goal_yaw_tolerance_ :
+                                      yaw_local_goal_tolerance_;
 
       double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, held_goal_pose_.theta));
       if (yaw_error >= held_yaw_tolerance)
@@ -737,8 +733,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         y = held_y;
         desired_angle = held_goal_pose_.theta;
         publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
-        ROS_DEBUG_NAMED("PathFollowerCritic",
-                        "Holding goal index %u until full pose tolerance satisfied (XY + yaw)", held_goal_index_);
+        ROS_DEBUG_NAMED("PathFollowerCritic", "Holding goal index %u until full pose tolerance satisfied (XY + yaw)",
+                        held_goal_index_);
         return true;
       }
 
@@ -750,9 +746,10 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       {
         reached_intermediate_goals_.push_back(reached_pose);
       }
-      ROS_DEBUG_NAMED("PathFollowerCritic",
-                      "Reached held intermediate goal index %u while respecting pose tolerances. last_progress_index_: %u",
-                      held_goal_index_, last_progress_index_);
+      ROS_DEBUG_NAMED(
+          "PathFollowerCritic",
+          "Reached held intermediate goal index %u while respecting pose tolerances. last_progress_index_: %u",
+          held_goal_index_, last_progress_index_);
       holding_goal_ = false;
     }
   }
@@ -780,7 +777,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   }
 
   auto articulationSearchStart = [&](unsigned int candidate_start) {
-    return std::max({candidate_start, articulation_scan_start, 1u});
+    return std::max({ candidate_start, articulation_scan_start, 1u });
   };
 
   unsigned int goal_index = search_start_index;
@@ -822,8 +819,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         reached_pose.theta = nearestPlanOrientation(reached_pose);
         if (reached_intermediate_goals_.empty() ||
             nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
-            fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) >
-                1e-6)
+            fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) > 1e-6)
         {
           reached_intermediate_goals_.push_back(reached_pose);
         }
@@ -846,10 +842,10 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
     if (articulation_lower_bound <= articulation_upper_bound)
     {
-      auto articulation_it = std::find_if(articulation_indices.begin(), articulation_indices.end(),
-                                          [&](unsigned int index) {
-                                            return index >= articulation_lower_bound && index <= articulation_upper_bound;
-                                          });
+      auto articulation_it =
+          std::find_if(articulation_indices.begin(), articulation_indices.end(), [&](unsigned int index) {
+            return index >= articulation_lower_bound && index <= articulation_upper_bound;
+          });
 
       if (articulation_it != articulation_indices.end())
       {
@@ -873,8 +869,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         forced_skipped_articulation = true;
         found_goal = true;
         ROS_DEBUG_NAMED("PathFollowerCritic",
-                        "Recovered skipped articulation index %u between progress %u and search start %u.",
-                        goal_index, last_progress_index_, search_start_index);
+                        "Recovered skipped articulation index %u between progress %u and search start %u.", goal_index,
+                        last_progress_index_, search_start_index);
       }
     }
   }
@@ -884,8 +880,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   {
     double candidate_yaw = goal_yaw;
     bool candidate_has_forward = false;
-    unsigned int candidate_index =
-        getGoalIndex(plan, search_index, last_valid_index, final_goal_in_plan_window, candidate_yaw, candidate_has_forward);
+    unsigned int candidate_index = getGoalIndex(plan, search_index, last_valid_index, final_goal_in_plan_window,
+                                                candidate_yaw, candidate_has_forward);
 
     bool forced_articulation = false;
     if (candidate_index > last_progress_index_)
@@ -895,8 +891,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       bool articulation_has_forward = candidate_has_forward;
       unsigned int articulation_start_index = articulationSearchStart(search_index);
       if (articulation_start_index <= candidate_index &&
-          findNextArticulation(plan, articulation_start_index, candidate_index, last_valid_index,
-                               articulation_index, articulation_yaw, articulation_has_forward))
+          findNextArticulation(plan, articulation_start_index, candidate_index, last_valid_index, articulation_index,
+                               articulation_yaw, articulation_has_forward))
       {
         candidate_index = articulation_index;
         candidate_yaw = articulation_yaw;
@@ -918,21 +914,19 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       found_goal = true;
       forced_skipped_articulation = true;
       has_next_articulation = false;
-      ROS_DEBUG_NAMED("PathFollowerCritic",
-                      "Selecting pending articulation index %u reached at candidate %u.", goal_index,
-                      candidate_index);
+      ROS_DEBUG_NAMED("PathFollowerCritic", "Selecting pending articulation index %u reached at candidate %u.",
+                      goal_index, candidate_index);
       break;
     }
 
-    double candidate_xy_tolerance =
-        (final_goal_in_plan_window && candidate_index == plan_last_index) ? final_goal_xy_tolerance_ :
-                                                                           xy_local_goal_tolerance_;
-    double candidate_yaw_tolerance =
-        (final_goal_in_plan_window && candidate_index == plan_last_index) ? final_goal_yaw_tolerance_ :
-                                                                            yaw_local_goal_tolerance_;
+    double candidate_xy_tolerance = (final_goal_in_plan_window && candidate_index == plan_last_index) ?
+                                        final_goal_xy_tolerance_ :
+                                        xy_local_goal_tolerance_;
+    double candidate_yaw_tolerance = (final_goal_in_plan_window && candidate_index == plan_last_index) ?
+                                         final_goal_yaw_tolerance_ :
+                                         yaw_local_goal_tolerance_;
 
-    if (isPoseReached(robot_pose, plan[candidate_index], candidate_yaw, candidate_xy_tolerance,
-                      candidate_yaw_tolerance))
+    if (isPoseReached(robot_pose, plan[candidate_index], candidate_yaw, candidate_xy_tolerance, candidate_yaw_tolerance))
     {
       last_progress_index_ = std::max(last_progress_index_, candidate_index);
       geometry_msgs::Pose2D reached_pose = plan[candidate_index];
@@ -943,9 +937,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       {
         reached_intermediate_goals_.push_back(reached_pose);
       }
-      ROS_DEBUG_NAMED("PathFollowerCritic",
-                      "Reached intermediate goal index %u. last_progress_index_: %u", candidate_index,
-                      last_progress_index_);
+      ROS_DEBUG_NAMED("PathFollowerCritic", "Reached intermediate goal index %u. last_progress_index_: %u",
+                      candidate_index, last_progress_index_);
 
       if (candidate_index >= last_valid_index)
       {
@@ -967,8 +960,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       double dot = to_goal_x * std::cos(candidate_yaw) + to_goal_y * std::sin(candidate_yaw);
       if (dot < 0.0)
       {
-        ROS_DEBUG_NAMED("PathFollowerCritic",
-                        "Skipping goal index %u due to backward alignment (dot product %.3f)", candidate_index, dot);
+        ROS_DEBUG_NAMED("PathFollowerCritic", "Skipping goal index %u due to backward alignment (dot product %.3f)",
+                        candidate_index, dot);
         if (candidate_index >= last_valid_index)
         {
           break;
@@ -1033,8 +1026,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       has_forward_direction = next_articulation_has_forward;
       has_next_articulation = false;
       forced_skipped_articulation = true;
-      ROS_DEBUG_NAMED("PathFollowerCritic",
-                      "Fallback switching to pending articulation index %u.", goal_index);
+      ROS_DEBUG_NAMED("PathFollowerCritic", "Fallback switching to pending articulation index %u.", goal_index);
     }
 
     if (goal_index > last_progress_index_)
@@ -1044,8 +1036,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       bool articulation_has_forward = has_forward_direction;
       unsigned int articulation_start_index = articulationSearchStart(search_start_index);
       if (articulation_start_index <= goal_index &&
-          findNextArticulation(plan, articulation_start_index, goal_index, last_valid_index,
-                               articulation_index, articulation_yaw, articulation_has_forward))
+          findNextArticulation(plan, articulation_start_index, goal_index, last_valid_index, articulation_index,
+                               articulation_yaw, articulation_has_forward))
       {
         goal_index = articulation_index;
         goal_yaw = articulation_yaw;
@@ -1057,8 +1049,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   bool pending_articulation = false;
   if (last_progress_index_ < goal_index)
   {
-    pending_articulation = std::find(articulation_indices.begin(), articulation_indices.end(), goal_index) !=
-                           articulation_indices.end();
+    pending_articulation =
+        std::find(articulation_indices.begin(), articulation_indices.end(), goal_index) != articulation_indices.end();
   }
 
   // Only consider snapping to the final goal yaw when we have already selected the last path index as goal.
@@ -1092,8 +1084,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     double position_diff_y = plan[goal_index].y - held_goal_pose_.y;
     double yaw_diff = angles::shortest_angular_distance(goal_yaw, held_goal_pose_.theta);
     same_as_held = (fabs(position_diff_x) <= hold_position_epsilon_) &&
-                   (fabs(position_diff_y) <= hold_position_epsilon_) &&
-                   (fabs(yaw_diff) <= hold_yaw_epsilon_);
+                   (fabs(position_diff_y) <= hold_position_epsilon_) && (fabs(yaw_diff) <= hold_yaw_epsilon_);
   }
 
   if (!same_as_held)
@@ -1111,8 +1102,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   holding_goal_ = true;
 
   ROS_DEBUG_NAMED("PathFollowerCritic",
-                  "Selected goal index %u (x: %.3f, y: %.3f, yaw: %.3f rad). last_progress_index_: %u",
-                  goal_index, plan[goal_index].x, plan[goal_index].y, goal_yaw, last_progress_index_);
+                  "Selected goal index %u (x: %.3f, y: %.3f, yaw: %.3f rad). last_progress_index_: %u", goal_index,
+                  plan[goal_index].x, plan[goal_index].y, goal_yaw, last_progress_index_);
 
   publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
   return true;
@@ -1196,8 +1187,7 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
     double length = hypot(direction_x, direction_y);
     if (length < epsilon)
     {
-      double orientation_delta =
-          fabs(angles::shortest_angular_distance(plan[goal_index].theta, plan[i].theta));
+      double orientation_delta = fabs(angles::shortest_angular_distance(plan[goal_index].theta, plan[i].theta));
       if (orientation_delta > orientation_progress_epsilon)
       {
         goal_index = i;

--- a/mir_dwb_critics/src/path_follower.cpp
+++ b/mir_dwb_critics/src/path_follower.cpp
@@ -180,6 +180,25 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   std::vector<geometry_msgs::Pose2D> plan = nav_2d_utils::adjustPlanResolution(global_plan, info.resolution).poses;
 
+  auto nearestPlanOrientation = [&](const geometry_msgs::Pose2D& query_pose) {
+    double best_distance = std::numeric_limits<double>::infinity();
+    double selected_orientation = query_pose.theta;
+
+    for (const auto& pose : global_plan.poses)
+    {
+      double dx = pose.x - query_pose.x;
+      double dy = pose.y - query_pose.y;
+      double distance = hypot(dx, dy);
+      if (distance < best_distance)
+      {
+        best_distance = distance;
+        selected_orientation = pose.theta;
+      }
+    }
+
+    return selected_orientation;
+  };
+
   auto posesDiffer = [&](const geometry_msgs::Pose2D& a, const geometry_msgs::Pose2D& b, double position_tolerance,
                          double yaw_tolerance) {
     double dx = a.x - b.x;
@@ -305,6 +324,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         geometry_msgs::Pose2D preserved_pose = reached_pose;
         preserved_pose.x = plan[matched_index].x;
         preserved_pose.y = plan[matched_index].y;
+        preserved_pose.theta = nearestPlanOrientation(preserved_pose);
         preserved_reached.emplace_back(matched_index, preserved_pose);
         state_preserved = true;
         progress_match_found = true;
@@ -321,6 +341,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         held_goal_index_ = held_match_index;
         held_goal_pose_.x = plan[held_match_index].x;
         held_goal_pose_.y = plan[held_match_index].y;
+        held_goal_pose_.theta = nearestPlanOrientation(held_goal_pose_);
       }
       else
       {
@@ -337,10 +358,10 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     {
       state_preserved = true;
 
-      double match_goal_yaw = plan[robot_match_index].theta;
+      double match_goal_yaw = nearestPlanOrientation(plan[robot_match_index]);
       if (!computeOutgoingAngle(plan, robot_match_index, match_goal_yaw))
       {
-        match_goal_yaw = plan[robot_match_index].theta;
+        match_goal_yaw = nearestPlanOrientation(plan[robot_match_index]);
       }
 
       bool match_is_final_index = ((robot_match_index + 1u) >= plan.size()) && final_goal_in_plan_window;
@@ -795,7 +816,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       {
         last_progress_index_ = std::max(last_progress_index_, idx);
         geometry_msgs::Pose2D reached_pose = plan[idx];
-        reached_pose.theta = articulation_goal_yaw;
+        reached_pose.theta = nearestPlanOrientation(reached_pose);
         if (reached_intermediate_goals_.empty() ||
             nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
             fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) >
@@ -915,7 +936,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     {
       last_progress_index_ = std::max(last_progress_index_, candidate_index);
       geometry_msgs::Pose2D reached_pose = plan[candidate_index];
-      reached_pose.theta = candidate_yaw;
+      reached_pose.theta = nearestPlanOrientation(reached_pose);
       if (reached_intermediate_goals_.empty() ||
           nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
           fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) > 1e-6)
@@ -1081,7 +1102,10 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   ROS_ASSERT(goal_index <= last_valid_index);
 
   worldToGridBounded(info, plan[goal_index].x, plan[goal_index].y, x, y);
-  desired_angle = goal_yaw;
+  geometry_msgs::Pose2D goal_pose = plan[goal_index];
+  double goal_plan_yaw = nearestPlanOrientation(goal_pose);
+  desired_angle = goal_plan_yaw;
+  goal_yaw = goal_plan_yaw;
 
   bool same_as_held = false;
   if (holding_goal_)
@@ -1096,15 +1120,15 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   if (!same_as_held)
   {
-    held_goal_pose_ = plan[goal_index];
-    held_goal_pose_.theta = goal_yaw;
+    held_goal_pose_ = goal_pose;
+    held_goal_pose_.theta = goal_plan_yaw;
     held_goal_index_ = goal_index;
   }
   else
   {
     held_goal_pose_.x = plan[goal_index].x;
     held_goal_pose_.y = plan[goal_index].y;
-    held_goal_pose_.theta = goal_yaw;
+    held_goal_pose_.theta = goal_plan_yaw;
   }
   holding_goal_ = true;
 
@@ -1302,12 +1326,6 @@ bool PathFollowerCritic::computeOutgoingAngle(const std::vector<geometry_msgs::P
   if (plan.empty() || index >= plan.size())
   {
     return false;
-  }
-
-  if (std::isfinite(plan[index].theta))
-  {
-    angle = plan[index].theta;
-    return true;
   }
 
   for (unsigned int i = index + 1; i < plan.size(); ++i)

--- a/mir_dwb_critics/src/path_follower.cpp
+++ b/mir_dwb_critics/src/path_follower.cpp
@@ -1054,28 +1054,6 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
   }
 
-  if (final_goal_in_plan_window && plan_last_index <= last_valid_index && goal_index != plan_last_index)
-  {
-    double snap_threshold = final_goal_xy_tolerance_;
-    if (snap_threshold >= 0.0)
-    {
-      double final_dx = plan[plan_last_index].x - plan[goal_index].x;
-      double final_dy = plan[plan_last_index].y - plan[goal_index].y;
-      double distance_to_final = hypot(final_dx, final_dy);
-      if (distance_to_final <= snap_threshold)
-      {
-        ROS_DEBUG_NAMED("PathFollowerCritic",
-                        "Snapping intermediate goal index %u to final goal because distance %.3f <= threshold %.3f",
-                        goal_index, distance_to_final, snap_threshold);
-        goal_index = plan_last_index;
-        goal_yaw = nearestPlanOrientation(plan[plan_last_index]);
-        has_forward_direction = false;
-        forced_skipped_articulation = false;
-        has_next_articulation = false;
-      }
-    }
-  }
-
   bool pending_articulation = false;
   if (last_progress_index_ < goal_index)
   {

--- a/mir_dwb_critics/src/path_follower.cpp
+++ b/mir_dwb_critics/src/path_follower.cpp
@@ -1304,6 +1304,12 @@ bool PathFollowerCritic::computeOutgoingAngle(const std::vector<geometry_msgs::P
     return false;
   }
 
+  if (std::isfinite(plan[index].theta))
+  {
+    angle = plan[index].theta;
+    return true;
+  }
+
   for (unsigned int i = index + 1; i < plan.size(); ++i)
   {
     double dx = plan[i].x - plan[index].x;

--- a/mir_dwb_critics/src/path_follower.cpp
+++ b/mir_dwb_critics/src/path_follower.cpp
@@ -88,6 +88,14 @@ void PathFollowerCritic::onInit()
   critic_nh_.param("heading_scale", heading_scale_, 1.0);
   critic_nh_.param("enforce_forward_dot", enforce_forward_dot_, true);
   critic_nh_.param("always_target_articulations", always_target_articulations_, true);
+  critic_nh_.param("intermediate_goal_spacing", intermediate_goal_spacing_, 0.5);
+  if (intermediate_goal_spacing_ < 0.0)
+  {
+    ROS_WARN_NAMED("PathFollowerCritic",
+                   "Parameter intermediate_goal_spacing (%.3f) is negative. Clamping to 0.0 to disable spacing limit.",
+                   intermediate_goal_spacing_);
+    intermediate_goal_spacing_ = 0.0;
+  }
   initial_alignment_done_ = false;
 
   intermediate_goal_pub_ = critic_nh_.advertise<geometry_msgs::PoseStamped>("intermediate_goal", 1);
@@ -198,6 +206,11 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
     return selected_orientation;
   };
+
+  for (auto& pose : plan)
+  {
+    pose.theta = nearestPlanOrientation(pose);
+  }
 
   auto posesDiffer = [&](const geometry_msgs::Pose2D& a, const geometry_msgs::Pose2D& b, double position_tolerance,
                          double yaw_tolerance) {
@@ -359,10 +372,6 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       state_preserved = true;
 
       double match_goal_yaw = nearestPlanOrientation(plan[robot_match_index]);
-      if (!computeOutgoingAngle(plan, robot_match_index, match_goal_yaw))
-      {
-        match_goal_yaw = nearestPlanOrientation(plan[robot_match_index]);
-      }
 
       bool match_is_final_index = ((robot_match_index + 1u) >= plan.size()) && final_goal_in_plan_window;
       double match_yaw_tolerance = match_is_final_index ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
@@ -654,15 +663,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   if (!initial_alignment_done_)
   {
-    double desired_initial_yaw = plan.front().theta;
-    if (!plan.empty())
-    {
-      double outgoing_angle = desired_initial_yaw;
-      if (computeOutgoingAngle(plan, 0u, outgoing_angle))
-      {
-        desired_initial_yaw = outgoing_angle;
-      }
-    }
+    double desired_initial_yaw = nearestPlanOrientation(robot_pose);
 
     double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, desired_initial_yaw));
     if (yaw_error >= yaw_local_goal_tolerance_)
@@ -781,7 +782,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   };
 
   unsigned int goal_index = search_start_index;
-  double goal_yaw = plan[goal_index].theta;
+  double goal_yaw = nearestPlanOrientation(plan[goal_index]);
   bool has_forward_direction = false;
   bool found_goal = false;
   bool forced_skipped_articulation = false;
@@ -802,9 +803,9 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         continue;
       }
 
-      double articulation_yaw = plan[idx].theta;
-      bool articulation_has_forward = computeOutgoingAngle(plan, idx, articulation_yaw);
-      double articulation_goal_yaw = articulation_has_forward ? articulation_yaw : plan[idx].theta;
+      double articulation_yaw = nearestPlanOrientation(plan[idx]);
+      bool articulation_has_forward = hasForwardProgress(plan, idx);
+      double articulation_goal_yaw = articulation_yaw;
 
       double articulation_xy_tolerance =
           (final_goal_in_plan_window && idx == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
@@ -851,11 +852,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       if (articulation_it != articulation_indices.end())
       {
         goal_index = *articulation_it;
-        has_forward_direction = computeOutgoingAngle(plan, goal_index, goal_yaw);
-        if (!has_forward_direction)
-        {
-          goal_yaw = plan[goal_index].theta;
-        }
+        has_forward_direction = hasForwardProgress(plan, goal_index);
+        goal_yaw = nearestPlanOrientation(plan[goal_index]);
 
         if (enforce_forward_dot_ && has_forward_direction)
         {
@@ -993,7 +991,8 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
     for (; goal_index <= last_valid_index; ++goal_index)
     {
-      has_forward_direction = computeOutgoingAngle(plan, goal_index, goal_yaw);
+      goal_yaw = nearestPlanOrientation(plan[goal_index]);
+      has_forward_direction = hasForwardProgress(plan, goal_index);
       if (has_forward_direction)
       {
         if (!enforce_forward_dot_)
@@ -1013,7 +1012,6 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         continue;
       }
 
-      goal_yaw = plan[goal_index].theta;
       if (!enforce_forward_dot_ || goal_index == last_valid_index)
       {
         selected_fallback = true;
@@ -1068,7 +1066,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
                         "Snapping intermediate goal index %u to final goal because distance %.3f <= threshold %.3f",
                         goal_index, distance_to_final, snap_threshold);
         goal_index = plan_last_index;
-        goal_yaw = plan[plan_last_index].theta;
+        goal_yaw = nearestPlanOrientation(plan[plan_last_index]);
         has_forward_direction = false;
         forced_skipped_articulation = false;
         has_next_articulation = false;
@@ -1094,7 +1092,7 @@ bool PathFollowerCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     if (final_distance <= final_goal_xy_tolerance_)
     {
       goal_index = plan_last_index;
-      goal_yaw = plan[plan_last_index].theta;
+      goal_yaw = nearestPlanOrientation(plan[plan_last_index]);
       has_forward_direction = false;
     }
   }
@@ -1154,13 +1152,17 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
   const double epsilon = 1e-9;
   unsigned int clamped_start = std::min(start_index, static_cast<unsigned int>(plan.size() - 1));
   unsigned int clamped_last = std::min(last_valid_index, static_cast<unsigned int>(plan.size() - 1));
+  double max_spacing = intermediate_goal_spacing_;
+  bool spacing_limit_enabled = max_spacing > 0.0;
+  double accumulated_distance = 0.0;
 
   if (clamped_start >= clamped_last)
   {
-    has_forward_direction = computeOutgoingAngle(plan, clamped_start, desired_angle);
-    if (!has_forward_direction)
+    desired_angle = plan[clamped_start].theta;
+    has_forward_direction = hasForwardProgress(plan, clamped_start);
+    if (plan_tail_is_final_goal && clamped_start == plan.size() - 1)
     {
-      desired_angle = plan[clamped_start].theta;
+      has_forward_direction = false;
     }
     return clamped_start;
   }
@@ -1171,8 +1173,6 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
   double previous_segment_angle = 0.0;
   bool previous_segment_angle_set = false;
   unsigned int previous_segment_end_index = clamped_start;
-  double last_valid_segment_angle = 0.0;
-  bool last_valid_segment_angle_set = false;
 
   for (unsigned int i = clamped_start + 1; i <= clamped_last; ++i)
   {
@@ -1184,9 +1184,13 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
       continue;
     }
 
+    accumulated_distance += length;
+    if (spacing_limit_enabled && accumulated_distance > max_spacing)
+    {
+      break;
+    }
+
     double current_angle = atan2(direction_y, direction_x);
-    last_valid_segment_angle = current_angle;
-    last_valid_segment_angle_set = true;
 
     if (!base_angle_set)
     {
@@ -1216,28 +1220,8 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
     previous_segment_angle_set = true;
   }
 
-  has_forward_direction = computeOutgoingAngle(plan, goal_index, desired_angle);
-  if (!has_forward_direction)
-  {
-    if (plan_tail_is_final_goal && goal_index == plan.size() - 1)
-    {
-      desired_angle = plan[goal_index].theta;
-    }
-    else if (previous_segment_angle_set)
-    {
-      desired_angle = previous_segment_angle;
-      has_forward_direction = true;
-    }
-    else if (last_valid_segment_angle_set)
-    {
-      desired_angle = last_valid_segment_angle;
-      has_forward_direction = true;
-    }
-    else
-    {
-      desired_angle = plan[goal_index].theta;
-    }
-  }
+  desired_angle = plan[goal_index].theta;
+  has_forward_direction = hasForwardProgress(plan, goal_index);
 
   if (plan_tail_is_final_goal && goal_index == plan.size() - 1)
   {
@@ -1297,16 +1281,8 @@ bool PathFollowerCritic::findNextArticulation(const std::vector<geometry_msgs::P
       if (articulation_angle >= articulation_angle_threshold_)
       {
         articulation_index = previous_segment_end_index;
-        articulation_yaw = current_angle;
-        has_forward_direction = true;
-        if (!computeOutgoingAngle(plan, articulation_index, articulation_yaw))
-        {
-          has_forward_direction = false;
-          if (articulation_index == plan.size() - 1)
-          {
-            articulation_yaw = plan[articulation_index].theta;
-          }
-        }
+        articulation_yaw = plan[articulation_index].theta;
+        has_forward_direction = hasForwardProgress(plan, articulation_index);
         return true;
       }
     }
@@ -1319,8 +1295,7 @@ bool PathFollowerCritic::findNextArticulation(const std::vector<geometry_msgs::P
   return false;
 }
 
-bool PathFollowerCritic::computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,
-                                              double& angle) const
+bool PathFollowerCritic::hasForwardProgress(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index) const
 {
   const double epsilon = 1e-9;
   if (plan.empty() || index >= plan.size())
@@ -1335,7 +1310,6 @@ bool PathFollowerCritic::computeOutgoingAngle(const std::vector<geometry_msgs::P
     double length = hypot(dx, dy);
     if (length >= epsilon)
     {
-      angle = atan2(dy, dx);
       return true;
     }
   }

--- a/mir_dwb_critics/src/path_follower.cpp
+++ b/mir_dwb_critics/src/path_follower.cpp
@@ -88,14 +88,16 @@ void PathFollowerCritic::onInit()
   critic_nh_.param("heading_scale", heading_scale_, 1.0);
   critic_nh_.param("enforce_forward_dot", enforce_forward_dot_, true);
   critic_nh_.param("always_target_articulations", always_target_articulations_, true);
-  critic_nh_.param("intermediate_goal_spacing", intermediate_goal_spacing_, 0.5);
-  if (intermediate_goal_spacing_ < 0.0)
+  int intermediate_goal_spacing_param = 0;
+  critic_nh_.param("intermediate_goal_spacing", intermediate_goal_spacing_param, 0);
+  if (intermediate_goal_spacing_param < 0)
   {
     ROS_WARN_NAMED("PathFollowerCritic",
-                   "Parameter intermediate_goal_spacing (%.3f) is negative. Clamping to 0.0 to disable spacing limit.",
-                   intermediate_goal_spacing_);
-    intermediate_goal_spacing_ = 0.0;
+                   "Parameter intermediate_goal_spacing (%d) is negative. Clamping to 0 to disable spacing limit.",
+                   intermediate_goal_spacing_param);
+    intermediate_goal_spacing_param = 0;
   }
+  intermediate_goal_spacing_ = static_cast<unsigned int>(intermediate_goal_spacing_param);
   initial_alignment_done_ = false;
 
   intermediate_goal_pub_ = critic_nh_.advertise<geometry_msgs::PoseStamped>("intermediate_goal", 1);
@@ -1152,9 +1154,9 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
   const double epsilon = 1e-9;
   unsigned int clamped_start = std::min(start_index, static_cast<unsigned int>(plan.size() - 1));
   unsigned int clamped_last = std::min(last_valid_index, static_cast<unsigned int>(plan.size() - 1));
-  double max_spacing = intermediate_goal_spacing_;
-  bool spacing_limit_enabled = max_spacing > 0.0;
-  double accumulated_distance = 0.0;
+  unsigned int max_spacing = intermediate_goal_spacing_;
+  bool spacing_limit_enabled = max_spacing > 0u;
+  const double orientation_progress_epsilon = 1e-3;
 
   if (clamped_start >= clamped_last)
   {
@@ -1181,11 +1183,23 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
     double length = hypot(direction_x, direction_y);
     if (length < epsilon)
     {
+      double orientation_delta =
+          fabs(angles::shortest_angular_distance(plan[goal_index].theta, plan[i].theta));
+      if (orientation_delta > orientation_progress_epsilon)
+      {
+        goal_index = i;
+        break;
+      }
+
+      if (spacing_limit_enabled && (i - clamped_start) > max_spacing)
+      {
+        break;
+      }
+
       continue;
     }
 
-    accumulated_distance += length;
-    if (spacing_limit_enabled && accumulated_distance > max_spacing)
+    if (spacing_limit_enabled && (i - clamped_start) > max_spacing)
     {
       break;
     }

--- a/mir_dwb_critics/src/path_follower.cpp
+++ b/mir_dwb_critics/src/path_follower.cpp
@@ -1155,7 +1155,28 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
   unsigned int clamped_start = std::min(start_index, static_cast<unsigned int>(plan.size() - 1));
   unsigned int clamped_last = std::min(last_valid_index, static_cast<unsigned int>(plan.size() - 1));
   unsigned int max_spacing = intermediate_goal_spacing_;
-  bool spacing_limit_enabled = max_spacing > 0u;
+  bool spacing_limit_enabled = true;
+  unsigned int loop_last = clamped_last;
+  if (max_spacing >= std::numeric_limits<unsigned int>::max())
+  {
+    spacing_limit_enabled = false;
+  }
+  else
+  {
+    unsigned int allowed_offset = max_spacing + 1u;
+    if (allowed_offset == 0u)
+    {
+      spacing_limit_enabled = false;
+    }
+    else if (clamped_start <= std::numeric_limits<unsigned int>::max() - allowed_offset)
+    {
+      unsigned int spacing_limit_index = clamped_start + allowed_offset;
+      if (spacing_limit_index < loop_last)
+      {
+        loop_last = spacing_limit_index;
+      }
+    }
+  }
   const double orientation_progress_epsilon = 1e-3;
 
   if (clamped_start >= clamped_last)
@@ -1169,6 +1190,19 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
     return clamped_start;
   }
 
+  if (spacing_limit_enabled)
+  {
+    unsigned int articulation_index = 0u;
+    double articulation_yaw = 0.0;
+    bool articulation_has_forward = false;
+    if (findNextArticulation(plan, clamped_start, clamped_last, last_valid_index, articulation_index, articulation_yaw,
+                             articulation_has_forward) &&
+        articulation_index > clamped_start)
+    {
+      loop_last = std::min(loop_last, articulation_index);
+    }
+  }
+
   unsigned int goal_index = clamped_start;
   double base_angle = 0.0;
   bool base_angle_set = false;
@@ -1176,7 +1210,8 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
   bool previous_segment_angle_set = false;
   unsigned int previous_segment_end_index = clamped_start;
 
-  for (unsigned int i = clamped_start + 1; i <= clamped_last; ++i)
+  unsigned int loop_end = spacing_limit_enabled ? std::min(loop_last, clamped_last) : clamped_last;
+  for (unsigned int i = clamped_start + 1; i <= loop_end; ++i)
   {
     double direction_x = plan[i].x - plan[i - 1].x;
     double direction_y = plan[i].y - plan[i - 1].y;
@@ -1191,17 +1226,8 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
         break;
       }
 
-      if (spacing_limit_enabled && (i - clamped_start) > max_spacing)
-      {
-        break;
-      }
-
+      goal_index = i;
       continue;
-    }
-
-    if (spacing_limit_enabled && (i - clamped_start) > max_spacing)
-    {
-      break;
     }
 
     double current_angle = atan2(direction_y, direction_x);
@@ -1232,6 +1258,11 @@ unsigned int PathFollowerCritic::getGoalIndex(const std::vector<geometry_msgs::P
     previous_segment_angle = current_angle;
     previous_segment_end_index = i;
     previous_segment_angle_set = true;
+  }
+
+  if (goal_index == clamped_start && loop_end > clamped_start)
+  {
+    goal_index = loop_end;
   }
 
   desired_angle = plan[goal_index].theta;

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -37,6 +37,7 @@
 #include <pluginlib/class_list_macros.h>
 #include <nav_2d_utils/path_ops.h>
 #include <sensor_msgs/PointCloud.h>
+#include <visualization_msgs/MarkerArray.h>
 #include <ros/node_handle.h>
 #include <ros/time.h>
 #include <tf2/LinearMath/Quaternion.h>
@@ -88,6 +89,8 @@ void PathProgressCritic::onInit()
 
   intermediate_goal_pub_ = critic_nh_.advertise<geometry_msgs::PoseStamped>("intermediate_goal", 1);
   articulation_points_pub_ = critic_nh_.advertise<sensor_msgs::PointCloud>("articulation_points", 1);
+  intermediate_goal_tolerance_pub_ =
+      critic_nh_.advertise<visualization_msgs::MarkerArray>("intermediate_goal_tolerance", 1);
 
   articulation_angle_threshold_ = std::max(articulation_angle_threshold_, angle_threshold_);
 
@@ -312,6 +315,34 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     goal_msg.pose.orientation.z = q.z();
     goal_msg.pose.orientation.w = q.w();
     intermediate_goal_pub_.publish(goal_msg);
+
+    if (intermediate_goal_tolerance_pub_)
+    {
+      visualization_msgs::MarkerArray marker_array;
+      visualization_msgs::Marker marker;
+      marker.header = goal_msg.header;
+      marker.header.stamp = goal_msg.header.stamp;
+      marker.ns = "intermediate_goal_tolerance";
+      marker.id = 0;
+      marker.type = visualization_msgs::Marker::SPHERE;
+      marker.action = visualization_msgs::Marker::ADD;
+      marker.pose.position = goal_msg.pose.position;
+      marker.pose.orientation.x = 0.0;
+      marker.pose.orientation.y = 0.0;
+      marker.pose.orientation.z = 0.0;
+      marker.pose.orientation.w = 1.0;
+      double diameter = std::max(2.0 * final_goal_xy_tolerance_, 1e-6);
+      marker.scale.x = diameter;
+      marker.scale.y = diameter;
+      marker.scale.z = diameter;
+      marker.color.r = 0.2f;
+      marker.color.g = 0.8f;
+      marker.color.b = 0.4f;
+      marker.color.a = 0.35f;
+      marker.lifetime = ros::Duration(0.0);
+      marker_array.markers.push_back(marker);
+      intermediate_goal_tolerance_pub_.publish(marker_array);
+    }
   };
 
   std::vector<unsigned int> articulation_indices = collectArticulationIndices(1u, plan_last_index);

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -210,27 +210,6 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
   }
 
-  // Constrain the search range to enforce monotonic progress.
-  last_progress_index_ = std::min(last_progress_index_, plan_last_index);
-
-  unsigned int search_start_index = std::max(start_index, last_progress_index_);
-  search_start_index = std::min(search_start_index, last_valid_index);
-
-  unsigned int articulation_scan_start = 0u;
-  if (plan_last_index >= 1)
-  {
-    unsigned int next_index = last_progress_index_ < plan_last_index ? last_progress_index_ + 1 : plan_last_index;
-    articulation_scan_start = std::max(next_index, 1u);
-  }
-  else
-  {
-    articulation_scan_start = plan_last_index;
-  }
-
-  auto articulationSearchStart = [&](unsigned int candidate_start) {
-    return std::max({candidate_start, articulation_scan_start, 1u});
-  };
-
   auto collectArticulationIndices = [&](unsigned int scan_start, unsigned int scan_end) {
     std::vector<unsigned int> articulation_indices;
     if (plan.size() < 2)
@@ -335,12 +314,22 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   if (holding_goal_)
   {
-    double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, held_goal_pose_.theta));
-    if (yaw_error >= final_goal_yaw_tolerance_)
+    unsigned int held_x = 0;
+    unsigned int held_y = 0;
+    bool held_in_costmap = worldToGridBounded(info, held_goal_pose_.x, held_goal_pose_.y, held_x, held_y);
+
+    if (!held_in_costmap)
     {
-      unsigned int held_x = 0;
-      unsigned int held_y = 0;
-      if (worldToGridBounded(info, held_goal_pose_.x, held_goal_pose_.y, held_x, held_y))
+      ROS_WARN_NAMED("PathProgressCritic",
+                     "Held goal (index %u) is outside the local costmap. Releasing hold to search for a new goal.",
+                     held_goal_index_);
+      holding_goal_ = false;
+      held_goal_index_ = 0;
+    }
+    else
+    {
+      double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, held_goal_pose_.theta));
+      if (yaw_error >= final_goal_yaw_tolerance_)
       {
         x = held_x;
         y = held_y;
@@ -351,18 +340,57 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         return true;
       }
 
-      ROS_WARN_NAMED("PathProgressCritic",
-                     "Held goal (index %u) is outside the local costmap. Releasing hold to search for a new goal.",
-                     held_goal_index_);
+      if (!isGoalReached(robot_pose, held_goal_pose_, held_goal_pose_.theta))
+      {
+        x = held_x;
+        y = held_y;
+        desired_angle = held_goal_pose_.theta;
+        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
+        ROS_DEBUG_NAMED("PathProgressCritic",
+                        "Holding goal index %u until full pose tolerance satisfied (XY + yaw)", held_goal_index_);
+        return true;
+      }
+
+      last_progress_index_ = std::max(last_progress_index_, held_goal_index_);
+      geometry_msgs::Pose2D reached_pose = held_goal_pose_;
+      if (reached_intermediate_goals_.empty() ||
+          nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
+          fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) > 1e-6)
+      {
+        reached_intermediate_goals_.push_back(reached_pose);
+      }
+      ROS_DEBUG_NAMED("PathProgressCritic",
+                      "Reached held intermediate goal index %u while respecting pose tolerances. last_progress_index_: %u",
+                      held_goal_index_, last_progress_index_);
       holding_goal_ = false;
-      held_goal_index_ = 0;
     }
   }
+
+  // Constrain the search range to enforce monotonic progress with the updated bookkeeping.
+  last_progress_index_ = std::min(last_progress_index_, plan_last_index);
+
+  unsigned int search_start_index = std::max(start_index, last_progress_index_);
+  search_start_index = std::min(search_start_index, last_valid_index);
 
   if (holding_goal_ && held_goal_index_ >= last_progress_index_)
   {
     search_start_index = std::min(search_start_index, held_goal_index_);
   }
+
+  unsigned int articulation_scan_start = 0u;
+  if (plan_last_index >= 1)
+  {
+    unsigned int next_index = last_progress_index_ < plan_last_index ? last_progress_index_ + 1 : plan_last_index;
+    articulation_scan_start = std::max(next_index, 1u);
+  }
+  else
+  {
+    articulation_scan_start = plan_last_index;
+  }
+
+  auto articulationSearchStart = [&](unsigned int candidate_start) {
+    return std::max({candidate_start, articulation_scan_start, 1u});
+  };
 
   unsigned int goal_index = search_start_index;
   double goal_yaw = plan[goal_index].theta;

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -32,9 +32,16 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <mir_dwb_critics/path_progress.h>
+#include <angles/angles.h>
+#include <geometry_msgs/PoseStamped.h>
 #include <nav_grid/coordinate_conversion.h>
 #include <pluginlib/class_list_macros.h>
 #include <nav_2d_utils/path_ops.h>
+#include <ros/time.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <algorithm>
+#include <cmath>
+#include <limits>
 #include <vector>
 
 namespace mir_dwb_critics
@@ -63,22 +70,32 @@ void PathProgressCritic::onInit()
 {
   dwb_critics::MapGridCritic::onInit();
   critic_nh_.param("xy_local_goal_tolerance", xy_local_goal_tolerance_, 0.20);
+  critic_nh_.param("yaw_local_goal_tolerance", yaw_local_goal_tolerance_, 0.15);
   critic_nh_.param("angle_threshold", angle_threshold_, M_PI_4);
+  critic_nh_.param("articulation_angle_threshold", articulation_angle_threshold_, 1.3089969389957472);
   critic_nh_.param("heading_scale", heading_scale_, 1.0);
+  critic_nh_.param("enforce_forward_dot", enforce_forward_dot_, true);
+
+  intermediate_goal_pub_ = critic_nh_.advertise<geometry_msgs::PoseStamped>("intermediate_goal", 1);
+
+  articulation_angle_threshold_ = std::max(articulation_angle_threshold_, angle_threshold_);
 
   // divide heading scale by position scale because the sum will be multiplied by scale again
   heading_scale_ /= getScale();
+  last_progress_index_ = 0;
+  reached_intermediate_goals_.clear();
 }
 
 void PathProgressCritic::reset()
 {
   reached_intermediate_goals_.clear();
+  last_progress_index_ = 0;
 }
 
 double PathProgressCritic::scoreTrajectory(const dwb_msgs::Trajectory2D& traj)
 {
   double position_score = MapGridCritic::scoreTrajectory(traj);
-  double heading_diff = fabs(remainder(traj.poses.back().theta - desired_angle_, 2 * M_PI));
+  double heading_diff = fabs(angles::shortest_angular_distance(traj.poses.back().theta, desired_angle_));
   double heading_score = heading_diff * heading_diff;
 
   return position_score + heading_scale_ * heading_score;
@@ -97,6 +114,12 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   }
 
   std::vector<geometry_msgs::Pose2D> plan = nav_2d_utils::adjustPlanResolution(global_plan, info.resolution).poses;
+
+  if (plan.empty())
+  {
+    ROS_ERROR_NAMED("PathProgressCritic", "The adjusted global plan was empty.");
+    return false;
+  }
 
   // find the "start pose", i.e. the pose on the plan closest to the robot that is also on the local map
   unsigned int start_index = 0;
@@ -157,94 +180,288 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
   }
 
-  // find the "goal pose" by walking along the plan as long as each step leads far enough away from the starting point,
-  // i.e. is within angle_threshold_ of the starting direction.
-  unsigned int goal_index = start_index;
+  // Constrain the search range to enforce monotonic progress.
+  last_progress_index_ = std::min(last_progress_index_, static_cast<unsigned int>(plan.size() - 1));
 
-  while (goal_index < last_valid_index)
+  unsigned int search_start_index = std::max(start_index, last_progress_index_);
+  search_start_index = std::min(search_start_index, last_valid_index);
+
+  unsigned int goal_index = search_start_index;
+  double goal_yaw = plan[goal_index].theta;
+  bool has_forward_direction = false;
+  bool found_goal = false;
+
+  unsigned int search_index = search_start_index;
+  while (search_index <= last_valid_index)
   {
-    goal_index = getGoalIndex(plan, start_index, last_valid_index);
+    double candidate_yaw = goal_yaw;
+    bool candidate_has_forward = false;
+    unsigned int candidate_index =
+        getGoalIndex(plan, search_index, last_valid_index, candidate_yaw, candidate_has_forward);
 
-    // check if goal already reached
-    bool goal_already_reached = false;
-    for (auto& reached_intermediate_goal : reached_intermediate_goals_)
+    candidate_index = std::max(candidate_index, search_index);
+
+    if (isGoalReached(robot_pose, plan[candidate_index], candidate_yaw))
     {
-      double distance = nav_2d_utils::poseDistance(reached_intermediate_goal, plan[goal_index]);
-      if (distance < xy_local_goal_tolerance_)
+      last_progress_index_ = std::max(last_progress_index_, candidate_index);
+      geometry_msgs::Pose2D reached_pose = plan[candidate_index];
+      reached_pose.theta = candidate_yaw;
+      if (reached_intermediate_goals_.empty() ||
+          nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
+          fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) > 1e-6)
       {
-        goal_already_reached = true;
-        // choose a new start_index by walking along the plan until we're outside xy_local_goal_tolerance_ and try again
-        // (start_index is now > goal_index)
-        for (start_index = goal_index; start_index <= last_valid_index; ++start_index)
+        reached_intermediate_goals_.push_back(reached_pose);
+      }
+      ROS_DEBUG_NAMED("PathProgressCritic",
+                      "Reached intermediate goal index %u. last_progress_index_: %u", candidate_index,
+                      last_progress_index_);
+
+      if (candidate_index >= last_valid_index)
+      {
+        goal_index = candidate_index;
+        goal_yaw = candidate_yaw;
+        has_forward_direction = candidate_has_forward;
+        found_goal = true;
+        break;
+      }
+
+      search_index = candidate_index + 1;
+      continue;
+    }
+
+    if (enforce_forward_dot_ && candidate_has_forward)
+    {
+      double to_goal_x = plan[candidate_index].x - robot_pose.x;
+      double to_goal_y = plan[candidate_index].y - robot_pose.y;
+      double dot = to_goal_x * std::cos(candidate_yaw) + to_goal_y * std::sin(candidate_yaw);
+      if (dot < 0.0)
+      {
+        ROS_DEBUG_NAMED("PathProgressCritic",
+                        "Skipping goal index %u due to backward alignment (dot product %.3f)", candidate_index, dot);
+        if (candidate_index >= last_valid_index)
         {
-          distance = nav_2d_utils::poseDistance(reached_intermediate_goal, plan[start_index]);
-          if (distance >= xy_local_goal_tolerance_)
-          {
-            break;
-          }
+          break;
         }
+        search_index = candidate_index + 1;
+        continue;
+      }
+    }
+
+    goal_index = candidate_index;
+    goal_yaw = candidate_yaw;
+    has_forward_direction = candidate_has_forward;
+    found_goal = true;
+    break;
+  }
+
+  if (!found_goal)
+  {
+    unsigned int fallback_start = std::min(last_valid_index, search_start_index);
+    goal_index = fallback_start;
+    bool selected_fallback = false;
+
+    for (; goal_index <= last_valid_index; ++goal_index)
+    {
+      has_forward_direction = computeOutgoingAngle(plan, goal_index, goal_yaw);
+      if (has_forward_direction)
+      {
+        if (!enforce_forward_dot_)
+        {
+          selected_fallback = true;
+          break;
+        }
+
+        double to_goal_x = plan[goal_index].x - robot_pose.x;
+        double to_goal_y = plan[goal_index].y - robot_pose.y;
+        double dot = to_goal_x * std::cos(goal_yaw) + to_goal_y * std::sin(goal_yaw);
+        if (dot >= 0.0)
+        {
+          selected_fallback = true;
+          break;
+        }
+        continue;
+      }
+
+      goal_yaw = plan[goal_index].theta;
+      if (!enforce_forward_dot_ || goal_index == last_valid_index)
+      {
+        selected_fallback = true;
         break;
       }
     }
-    if (!goal_already_reached)
+
+    if (!selected_fallback)
     {
-      // new goal not in reached_intermediate_goals_
-      double distance = nav_2d_utils::poseDistance(plan[goal_index], robot_pose);
-      if (distance < xy_local_goal_tolerance_)
-      {
-        // the robot has currently reached the goal
-        reached_intermediate_goals_.push_back(plan[goal_index]);
-        ROS_DEBUG_NAMED("PathProgressCritic", "Number of reached_intermediate goals: %zu",
-                        reached_intermediate_goals_.size());
-      }
-      else
-      {
-        // we've found a new goal!
-        break;
-      }
+      return false;
     }
   }
-  if (start_index > goal_index)
-    start_index = goal_index;
+
   ROS_ASSERT(goal_index <= last_valid_index);
 
-  // save goal in x, y
   worldToGridBounded(info, plan[goal_index].x, plan[goal_index].y, x, y);
-  desired_angle = plan[start_index].theta;
+  desired_angle = goal_yaw;
+
+  ROS_DEBUG_NAMED("PathProgressCritic",
+                  "Selected goal index %u (x: %.3f, y: %.3f, yaw: %.3f rad). last_progress_index_: %u",
+                  goal_index, plan[goal_index].x, plan[goal_index].y, goal_yaw, last_progress_index_);
+
+  if (intermediate_goal_pub_)
+  {
+    geometry_msgs::PoseStamped goal_pose;
+    goal_pose.header = global_plan.header;
+    goal_pose.header.stamp = ros::Time::now();
+    goal_pose.pose.position.x = plan[goal_index].x;
+    goal_pose.pose.position.y = plan[goal_index].y;
+    goal_pose.pose.position.z = 0.0;
+    tf2::Quaternion q;
+    q.setRPY(0.0, 0.0, goal_yaw);
+    goal_pose.pose.orientation.x = q.x();
+    goal_pose.pose.orientation.y = q.y();
+    goal_pose.pose.orientation.z = q.z();
+    goal_pose.pose.orientation.w = q.w();
+    intermediate_goal_pub_.publish(goal_pose);
+  }
   return true;
 }
 
 unsigned int PathProgressCritic::getGoalIndex(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
-                                              unsigned int last_valid_index) const
+                                              unsigned int last_valid_index, double& desired_angle,
+                                              bool& has_forward_direction) const
 {
-  if (start_index >= last_valid_index)
-    return last_valid_index;
-
-  unsigned int goal_index = start_index;
-  const double start_direction_x = plan[start_index + 1].x - plan[start_index].x;
-  const double start_direction_y = plan[start_index + 1].y - plan[start_index].y;
-  if (fabs(start_direction_x) > 1e-9 || fabs(start_direction_y) > 1e-9)
+  if (plan.empty())
   {
-    // make sure that atan2 is defined
-    double start_angle = atan2(start_direction_y, start_direction_x);
+    desired_angle = 0.0;
+    has_forward_direction = false;
+    return 0;
+  }
 
-    for (unsigned int i = start_index + 1; i <= last_valid_index; ++i)
+  const double epsilon = 1e-9;
+  unsigned int clamped_start = std::min(start_index, static_cast<unsigned int>(plan.size() - 1));
+  unsigned int clamped_last = std::min(last_valid_index, static_cast<unsigned int>(plan.size() - 1));
+
+  if (clamped_start >= clamped_last)
+  {
+    has_forward_direction = computeOutgoingAngle(plan, clamped_start, desired_angle);
+    if (!has_forward_direction)
     {
-      const double current_direction_x = plan[i].x - plan[i - 1].x;
-      const double current_direction_y = plan[i].y - plan[i - 1].y;
-      if (fabs(current_direction_x) > 1e-9 || fabs(current_direction_y) > 1e-9)
+      desired_angle = plan[clamped_start].theta;
+    }
+    return clamped_start;
+  }
+
+  unsigned int goal_index = clamped_start;
+  double base_angle = 0.0;
+  bool base_angle_set = false;
+  double previous_segment_angle = 0.0;
+  bool previous_segment_angle_set = false;
+  unsigned int previous_segment_end_index = clamped_start;
+  double last_valid_segment_angle = 0.0;
+  bool last_valid_segment_angle_set = false;
+
+  for (unsigned int i = clamped_start + 1; i <= clamped_last; ++i)
+  {
+    double direction_x = plan[i].x - plan[i - 1].x;
+    double direction_y = plan[i].y - plan[i - 1].y;
+    double length = hypot(direction_x, direction_y);
+    if (length < epsilon)
+    {
+      continue;
+    }
+
+    double current_angle = atan2(direction_y, direction_x);
+    last_valid_segment_angle = current_angle;
+    last_valid_segment_angle_set = true;
+
+    if (!base_angle_set)
+    {
+      base_angle = current_angle;
+      base_angle_set = true;
+    }
+
+    if (previous_segment_angle_set)
+    {
+      double articulation_angle = fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
+      if (articulation_angle >= articulation_angle_threshold_)
       {
-        double current_angle = atan2(current_direction_y, current_direction_x);
-
-        // goal pose is found if plan doesn't point far enough away from the starting point
-        if (fabs(remainder(start_angle - current_angle, 2 * M_PI)) > angle_threshold_)
-          break;
-
-        goal_index = i;
+        goal_index = previous_segment_end_index;
+        break;
       }
     }
+
+    double deviation = fabs(angles::shortest_angular_distance(base_angle, current_angle));
+    if (deviation > angle_threshold_)
+    {
+      break;
+    }
+
+    goal_index = i;
+    previous_segment_angle = current_angle;
+    previous_segment_end_index = i;
+    previous_segment_angle_set = true;
   }
+
+  has_forward_direction = computeOutgoingAngle(plan, goal_index, desired_angle);
+  if (!has_forward_direction)
+  {
+    if (goal_index == plan.size() - 1)
+    {
+      desired_angle = plan[goal_index].theta;
+    }
+    else if (previous_segment_angle_set)
+    {
+      desired_angle = previous_segment_angle;
+      has_forward_direction = true;
+    }
+    else if (last_valid_segment_angle_set)
+    {
+      desired_angle = last_valid_segment_angle;
+      has_forward_direction = true;
+    }
+    else
+    {
+      desired_angle = plan[goal_index].theta;
+    }
+  }
+
+  if (goal_index == plan.size() - 1)
+  {
+    has_forward_direction = false;
+  }
+
   return goal_index;
+}
+
+bool PathProgressCritic::computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,
+                                              double& angle) const
+{
+  const double epsilon = 1e-9;
+  if (plan.empty() || index >= plan.size())
+  {
+    return false;
+  }
+
+  for (unsigned int i = index + 1; i < plan.size(); ++i)
+  {
+    double dx = plan[i].x - plan[index].x;
+    double dy = plan[i].y - plan[index].y;
+    double length = hypot(dx, dy);
+    if (length >= epsilon)
+    {
+      angle = atan2(dy, dx);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool PathProgressCritic::isGoalReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
+                                       double goal_yaw) const
+{
+  double distance = nav_2d_utils::poseDistance(goal_pose, robot_pose);
+  double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, goal_yaw));
+
+  return distance < xy_local_goal_tolerance_ && yaw_error < yaw_local_goal_tolerance_;
 }
 
 }  // namespace mir_dwb_critics

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -159,6 +159,25 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   std::vector<geometry_msgs::Pose2D> plan = nav_2d_utils::adjustPlanResolution(global_plan, info.resolution).poses;
 
+  auto planPoseMatchesFinalGoal = [&](const geometry_msgs::Pose2D& plan_pose) {
+    double dx = plan_pose.x - goal.x;
+    double dy = plan_pose.y - goal.y;
+    double distance = hypot(dx, dy);
+    if (distance > plan_alignment_position_tolerance_)
+    {
+      return false;
+    }
+
+    double yaw_error = fabs(angles::shortest_angular_distance(plan_pose.theta, goal.theta));
+    return yaw_error <= plan_alignment_yaw_tolerance_;
+  };
+
+  bool final_goal_in_plan_window = false;
+  if (!plan.empty())
+  {
+    final_goal_in_plan_window = planPoseMatchesFinalGoal(plan.back());
+  }
+
   auto plansEqual = [&](const std::vector<geometry_msgs::Pose2D>& a,
                         const std::vector<geometry_msgs::Pose2D>& b) {
     if (a.size() != b.size())
@@ -284,7 +303,7 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         match_goal_yaw = plan[robot_match_index].theta;
       }
 
-      bool match_is_final_index = (robot_match_index + 1u) >= plan.size();
+      bool match_is_final_index = ((robot_match_index + 1u) >= plan.size()) && final_goal_in_plan_window;
       double match_yaw_tolerance = match_is_final_index ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
       double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, match_goal_yaw));
 
@@ -632,8 +651,12 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
     else
     {
-      double held_xy_tolerance = (held_goal_index_ == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
-      double held_yaw_tolerance = (held_goal_index_ == plan_last_index) ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
+      double held_xy_tolerance =
+          (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ? final_goal_xy_tolerance_ :
+                                                                             xy_local_goal_tolerance_;
+      double held_yaw_tolerance =
+          (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ? final_goal_yaw_tolerance_ :
+                                                                              yaw_local_goal_tolerance_;
 
       double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, held_goal_pose_.theta));
       if (yaw_error >= held_yaw_tolerance)
@@ -725,8 +748,10 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       bool articulation_has_forward = computeOutgoingAngle(plan, idx, articulation_yaw);
       double articulation_goal_yaw = articulation_has_forward ? articulation_yaw : plan[idx].theta;
 
-      double articulation_xy_tolerance = (idx == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
-      double articulation_yaw_tolerance = (idx == plan_last_index) ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
+      double articulation_xy_tolerance =
+          (final_goal_in_plan_window && idx == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
+      double articulation_yaw_tolerance =
+          (final_goal_in_plan_window && idx == plan_last_index) ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
 
       if (isPoseReached(robot_pose, plan[idx], articulation_goal_yaw, articulation_xy_tolerance,
                         articulation_yaw_tolerance))
@@ -802,7 +827,7 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     double candidate_yaw = goal_yaw;
     bool candidate_has_forward = false;
     unsigned int candidate_index =
-        getGoalIndex(plan, search_index, last_valid_index, candidate_yaw, candidate_has_forward);
+        getGoalIndex(plan, search_index, last_valid_index, final_goal_in_plan_window, candidate_yaw, candidate_has_forward);
 
     bool forced_articulation = false;
     if (candidate_index > last_progress_index_)
@@ -841,8 +866,12 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       break;
     }
 
-    double candidate_xy_tolerance = (candidate_index == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
-    double candidate_yaw_tolerance = (candidate_index == plan_last_index) ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
+    double candidate_xy_tolerance =
+        (final_goal_in_plan_window && candidate_index == plan_last_index) ? final_goal_xy_tolerance_ :
+                                                                           xy_local_goal_tolerance_;
+    double candidate_yaw_tolerance =
+        (final_goal_in_plan_window && candidate_index == plan_last_index) ? final_goal_yaw_tolerance_ :
+                                                                            yaw_local_goal_tolerance_;
 
     if (isPoseReached(robot_pose, plan[candidate_index], candidate_yaw, candidate_xy_tolerance,
                       candidate_yaw_tolerance))
@@ -967,7 +996,7 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
   }
 
-  if (plan_last_index <= last_valid_index && goal_index != plan_last_index)
+  if (final_goal_in_plan_window && plan_last_index <= last_valid_index && goal_index != plan_last_index)
   {
     double snap_threshold = final_goal_xy_tolerance_;
     if (snap_threshold >= 0.0)
@@ -998,8 +1027,8 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   // Only consider snapping to the final goal yaw when we have already selected the last path index as goal.
   // Otherwise, keep following the path even if the final goal is within tolerance.
-  if (!pending_articulation && final_goal_xy_tolerance_ >= 0.0 && plan_last_index <= last_valid_index &&
-      goal_index == plan_last_index)
+  if (!pending_articulation && final_goal_xy_tolerance_ >= 0.0 && final_goal_in_plan_window &&
+      plan_last_index <= last_valid_index && goal_index == plan_last_index)
   {
     double final_dx = plan[plan_last_index].x - plan[goal_index].x;
     double final_dy = plan[plan_last_index].y - plan[goal_index].y;
@@ -1051,8 +1080,8 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 }
 
 unsigned int PathProgressCritic::getGoalIndex(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
-                                              unsigned int last_valid_index, double& desired_angle,
-                                              bool& has_forward_direction) const
+                                              unsigned int last_valid_index, bool plan_tail_is_final_goal,
+                                              double& desired_angle, bool& has_forward_direction) const
 {
   if (plan.empty())
   {
@@ -1129,7 +1158,7 @@ unsigned int PathProgressCritic::getGoalIndex(const std::vector<geometry_msgs::P
   has_forward_direction = computeOutgoingAngle(plan, goal_index, desired_angle);
   if (!has_forward_direction)
   {
-    if (goal_index == plan.size() - 1)
+    if (plan_tail_is_final_goal && goal_index == plan.size() - 1)
     {
       desired_angle = plan[goal_index].theta;
     }
@@ -1149,7 +1178,7 @@ unsigned int PathProgressCritic::getGoalIndex(const std::vector<geometry_msgs::P
     }
   }
 
-  if (goal_index == plan.size() - 1)
+  if (plan_tail_is_final_goal && goal_index == plan.size() - 1)
   {
     has_forward_direction = false;
   }

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -33,10 +33,10 @@
  */
 #include <mir_dwb_critics/path_progress.h>
 #include <angles/angles.h>
-#include <geometry_msgs/PoseStamped.h>
 #include <nav_grid/coordinate_conversion.h>
 #include <pluginlib/class_list_macros.h>
 #include <nav_2d_utils/path_ops.h>
+#include <sensor_msgs/PointCloud.h>
 #include <ros/node_handle.h>
 #include <ros/time.h>
 #include <tf2/LinearMath/Quaternion.h>
@@ -83,6 +83,7 @@ void PathProgressCritic::onInit()
   critic_nh_.param("enforce_forward_dot", enforce_forward_dot_, true);
 
   intermediate_goal_pub_ = critic_nh_.advertise<geometry_msgs::PoseStamped>("intermediate_goal", 1);
+  articulation_points_pub_ = critic_nh_.advertise<sensor_msgs::PointCloud>("articulation_points", 1);
 
   articulation_angle_threshold_ = std::max(articulation_angle_threshold_, angle_threshold_);
 
@@ -139,6 +140,8 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     ROS_ERROR_NAMED("PathProgressCritic", "The adjusted global plan was empty.");
     return false;
   }
+
+  const unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
 
   if (holding_goal_ && held_goal_index_ >= plan.size())
   {
@@ -208,7 +211,6 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   }
 
   // Constrain the search range to enforce monotonic progress.
-  unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
   last_progress_index_ = std::min(last_progress_index_, plan_last_index);
 
   unsigned int search_start_index = std::max(start_index, last_progress_index_);
@@ -227,6 +229,85 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   auto articulationSearchStart = [&](unsigned int candidate_start) {
     return std::max({candidate_start, articulation_scan_start, 1u});
+  };
+
+  auto collectArticulationIndices = [&](unsigned int scan_start, unsigned int scan_end) {
+    std::vector<unsigned int> articulation_indices;
+    if (plan.size() < 2)
+    {
+      return articulation_indices;
+    }
+
+    const double epsilon = 1e-9;
+    unsigned int clamped_start = std::max(scan_start, 1u);
+    unsigned int clamped_end = std::min(scan_end, plan_last_index);
+    if (clamped_start > clamped_end)
+    {
+      return articulation_indices;
+    }
+
+    double previous_segment_angle = 0.0;
+    bool previous_segment_angle_set = false;
+    unsigned int previous_segment_end_index = 0u;
+
+    for (unsigned int i = clamped_start; i <= clamped_end; ++i)
+    {
+      double direction_x = plan[i].x - plan[i - 1].x;
+      double direction_y = plan[i].y - plan[i - 1].y;
+      double length = hypot(direction_x, direction_y);
+      if (length < epsilon)
+      {
+        continue;
+      }
+
+      double current_angle = atan2(direction_y, direction_x);
+      if (previous_segment_angle_set)
+      {
+        double articulation_angle =
+            fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
+        if (articulation_angle >= articulation_angle_threshold_)
+        {
+          if (articulation_indices.empty() || articulation_indices.back() != previous_segment_end_index)
+          {
+            articulation_indices.push_back(previous_segment_end_index);
+          }
+        }
+      }
+
+      previous_segment_angle = current_angle;
+      previous_segment_angle_set = true;
+      previous_segment_end_index = i;
+    }
+
+    return articulation_indices;
+  };
+
+  auto publishArticulationPointCloud = [&](const std::vector<unsigned int>& articulation_indices) {
+    if (!articulation_points_pub_)
+    {
+      return;
+    }
+
+    sensor_msgs::PointCloud cloud_msg;
+    cloud_msg.header = global_plan.header;
+    cloud_msg.header.stamp = ros::Time::now();
+    cloud_msg.points.reserve(articulation_indices.size());
+
+    for (unsigned int index : articulation_indices)
+    {
+      if (index >= plan.size())
+      {
+        continue;
+      }
+
+      geometry_msgs::Point32 point;
+      point.x = plan[index].x;
+      point.y = plan[index].y;
+      point.z = 0.0;
+      cloud_msg.points.push_back(point);
+    }
+
+    articulation_points_pub_.publish(cloud_msg);
   };
 
   auto publishIntermediateGoal = [&](const geometry_msgs::Pose2D& goal_pose, double goal_yaw) {
@@ -248,6 +329,9 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     goal_msg.pose.orientation.w = q.w();
     intermediate_goal_pub_.publish(goal_msg);
   };
+
+  std::vector<unsigned int> articulation_indices = collectArticulationIndices(1u, plan_last_index);
+  publishArticulationPointCloud(articulation_indices);
 
   if (holding_goal_)
   {

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -86,6 +86,7 @@ void PathProgressCritic::onInit()
   critic_nh_.param("articulation_angle_threshold", articulation_angle_threshold_, 1.3089969389957472);
   critic_nh_.param("heading_scale", heading_scale_, 1.0);
   critic_nh_.param("enforce_forward_dot", enforce_forward_dot_, true);
+  critic_nh_.param("always_target_articulations", always_target_articulations_, true);
 
   intermediate_goal_pub_ = critic_nh_.advertise<geometry_msgs::PoseStamped>("intermediate_goal", 1);
   articulation_points_pub_ = critic_nh_.advertise<sensor_msgs::PointCloud>("articulation_points", 1);
@@ -434,7 +435,50 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   bool found_goal = false;
   bool forced_skipped_articulation = false;
 
-  if (search_start_index > last_progress_index_ + 1 && !articulation_indices.empty())
+  if (always_target_articulations_ && !articulation_indices.empty())
+  {
+    unsigned int window_start = std::max(search_start_index, last_progress_index_ + 1);
+    unsigned int window_end = last_valid_index;
+
+    for (unsigned int idx : articulation_indices)
+    {
+      if (idx < window_start || idx > window_end)
+      {
+        continue;
+      }
+
+      double articulation_yaw = plan[idx].theta;
+      bool articulation_has_forward = computeOutgoingAngle(plan, idx, articulation_yaw);
+      double goal_candidate_yaw = articulation_has_forward ? articulation_yaw : plan[idx].theta;
+
+      if (isGoalReached(robot_pose, plan[idx], goal_candidate_yaw))
+      {
+        last_progress_index_ = std::max(last_progress_index_, idx);
+        geometry_msgs::Pose2D reached_pose = plan[idx];
+        reached_pose.theta = goal_candidate_yaw;
+        if (reached_intermediate_goals_.empty() ||
+            nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
+            fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) >
+                1e-6)
+        {
+          reached_intermediate_goals_.push_back(reached_pose);
+        }
+        continue;
+      }
+
+      goal_index = idx;
+      goal_yaw = goal_candidate_yaw;
+      has_forward_direction = articulation_has_forward;
+      found_goal = true;
+      forced_skipped_articulation = true;
+      ROS_DEBUG_NAMED("PathProgressCritic",
+                      "Selecting articulation index %u as prioritized intermediate goal. last_progress_index_: %u",
+                      goal_index, last_progress_index_);
+      break;
+    }
+  }
+
+  if (!found_goal && search_start_index > last_progress_index_ + 1 && !articulation_indices.empty())
   {
     unsigned int articulation_lower_bound = std::max(last_progress_index_ + 1, 1u);
     unsigned int articulation_upper_bound = std::min(search_start_index - 1, last_valid_index);
@@ -607,7 +651,7 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       unsigned int articulation_index = 0;
       double articulation_yaw = goal_yaw;
       bool articulation_has_forward = has_forward_direction;
-      unsigned int articulation_start_index = articulationSearchStart(goal_index);
+      unsigned int articulation_start_index = articulationSearchStart(search_start_index);
       if (articulation_start_index <= goal_index &&
           findNextArticulation(plan, articulation_start_index, goal_index, last_valid_index,
                                articulation_index, articulation_yaw, articulation_has_forward))

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -557,6 +557,15 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   if (!initial_alignment_done_)
   {
     double desired_initial_yaw = plan.front().theta;
+    if (!plan.empty())
+    {
+      double outgoing_angle = desired_initial_yaw;
+      if (computeOutgoingAngle(plan, 0u, outgoing_angle))
+      {
+        desired_initial_yaw = outgoing_angle;
+      }
+    }
+
     double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, desired_initial_yaw));
     if (yaw_error >= yaw_local_goal_tolerance_)
     {
@@ -602,19 +611,22 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
     else
     {
+      double held_xy_tolerance = (held_goal_index_ == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
+      double held_yaw_tolerance = (held_goal_index_ == plan_last_index) ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
+
       double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, held_goal_pose_.theta));
-      if (yaw_error >= final_goal_yaw_tolerance_)
+      if (yaw_error >= held_yaw_tolerance)
       {
         x = held_x;
         y = held_y;
         desired_angle = held_goal_pose_.theta;
         publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
         ROS_DEBUG_NAMED("PathProgressCritic", "Holding goal index %u due to yaw error %.3f rad (threshold %.3f)",
-                        held_goal_index_, yaw_error, final_goal_yaw_tolerance_);
+                        held_goal_index_, yaw_error, held_yaw_tolerance);
         return true;
       }
 
-      if (!isGoalReached(robot_pose, held_goal_pose_, held_goal_pose_.theta))
+      if (!isPoseReached(robot_pose, held_goal_pose_, held_goal_pose_.theta, held_xy_tolerance, held_yaw_tolerance))
       {
         x = held_x;
         y = held_y;
@@ -692,7 +704,11 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       bool articulation_has_forward = computeOutgoingAngle(plan, idx, articulation_yaw);
       double articulation_goal_yaw = articulation_has_forward ? articulation_yaw : plan[idx].theta;
 
-      if (isGoalReached(robot_pose, plan[idx], articulation_goal_yaw))
+      double articulation_xy_tolerance = (idx == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
+      double articulation_yaw_tolerance = (idx == plan_last_index) ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
+
+      if (isPoseReached(robot_pose, plan[idx], articulation_goal_yaw, articulation_xy_tolerance,
+                        articulation_yaw_tolerance))
       {
         last_progress_index_ = std::max(last_progress_index_, idx);
         geometry_msgs::Pose2D reached_pose = plan[idx];
@@ -804,7 +820,11 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       break;
     }
 
-    if (isGoalReached(robot_pose, plan[candidate_index], candidate_yaw))
+    double candidate_xy_tolerance = (candidate_index == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
+    double candidate_yaw_tolerance = (candidate_index == plan_last_index) ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
+
+    if (isPoseReached(robot_pose, plan[candidate_index], candidate_yaw, candidate_xy_tolerance,
+                      candidate_yaw_tolerance))
     {
       last_progress_index_ = std::max(last_progress_index_, candidate_index);
       geometry_msgs::Pose2D reached_pose = plan[candidate_index];
@@ -943,6 +963,7 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     double final_distance = hypot(final_dx, final_dy);
     if (final_distance <= final_goal_xy_tolerance_)
     {
+      goal_index = plan_last_index;
       goal_yaw = plan[plan_last_index].theta;
       has_forward_direction = false;
     }
@@ -1189,13 +1210,19 @@ bool PathProgressCritic::computeOutgoingAngle(const std::vector<geometry_msgs::P
   return false;
 }
 
-bool PathProgressCritic::isGoalReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
-                                       double goal_yaw) const
+bool PathProgressCritic::isPoseReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
+                                       double goal_yaw, double xy_tolerance, double yaw_tolerance) const
 {
   double distance = nav_2d_utils::poseDistance(goal_pose, robot_pose);
   double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, goal_yaw));
 
-  return distance < xy_local_goal_tolerance_ && yaw_error < yaw_local_goal_tolerance_;
+  return distance < xy_tolerance && yaw_error < yaw_tolerance;
+}
+
+bool PathProgressCritic::isGoalReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
+                                       double goal_yaw) const
+{
+  return isPoseReached(robot_pose, goal_pose, goal_yaw, xy_local_goal_tolerance_, yaw_local_goal_tolerance_);
 }
 
 }  // namespace mir_dwb_critics

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -55,7 +55,7 @@ bool PathProgressCritic::prepare(const geometry_msgs::Pose2D& pose, const nav_2d
   dwb_critics::MapGridCritic::reset();
 
   unsigned int local_goal_x, local_goal_y;
-  if (!getGoalPose(pose, global_plan, local_goal_x, local_goal_y, desired_angle_))
+  if (!getGoalPose(pose, goal, global_plan, local_goal_x, local_goal_y, desired_angle_))
   {
     return false;
   }
@@ -117,9 +117,14 @@ void PathProgressCritic::onInit()
   last_plan_end_pose_.theta = 0.0;
   last_plan_frame_id_.clear();
   last_plan_stamp_ = ros::Time(0);
-  last_plan_.clear();
-  plan_position_epsilon_ = 1e-4;
-  plan_yaw_epsilon_ = 1e-4;
+  last_plan_seq_ = 0u;
+  last_plan_start_pose_.x = 0.0;
+  last_plan_start_pose_.y = 0.0;
+  last_plan_start_pose_.theta = 0.0;
+  last_final_goal_pose_.x = 0.0;
+  last_final_goal_pose_.y = 0.0;
+  last_final_goal_pose_.theta = 0.0;
+  have_last_goal_pose_ = false;
   critic_nh_.param("plan_alignment_position_tolerance", plan_alignment_position_tolerance_, 0.15);
   critic_nh_.param("plan_alignment_yaw_tolerance", plan_alignment_yaw_tolerance_, 3.14159265358979323846);
 }
@@ -134,6 +139,21 @@ void PathProgressCritic::reset()
   held_goal_pose_.y = 0.0;
   held_goal_pose_.theta = 0.0;
   initial_alignment_done_ = false;
+  have_last_plan_ = false;
+  last_plan_size_ = 0;
+  last_plan_end_pose_.x = 0.0;
+  last_plan_end_pose_.y = 0.0;
+  last_plan_end_pose_.theta = 0.0;
+  last_plan_frame_id_.clear();
+  last_plan_stamp_ = ros::Time(0);
+  last_plan_seq_ = 0u;
+  last_plan_start_pose_.x = 0.0;
+  last_plan_start_pose_.y = 0.0;
+  last_plan_start_pose_.theta = 0.0;
+  last_final_goal_pose_.x = 0.0;
+  last_final_goal_pose_.y = 0.0;
+  last_final_goal_pose_.theta = 0.0;
+  have_last_goal_pose_ = false;
 }
 
 double PathProgressCritic::scoreTrajectory(const dwb_msgs::Trajectory2D& traj)
@@ -145,8 +165,9 @@ double PathProgressCritic::scoreTrajectory(const dwb_msgs::Trajectory2D& traj)
   return position_score + heading_scale_ * heading_score;
 }
 
-bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, const nav_2d_msgs::Path2D& global_plan,
-                                     unsigned int& x, unsigned int& y, double& desired_angle)
+bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& final_goal,
+                                     const nav_2d_msgs::Path2D& global_plan, unsigned int& x, unsigned int& y,
+                                     double& desired_angle)
 {
   const nav_core2::Costmap& costmap = *costmap_;
   const nav_grid::NavGridInfo& info = costmap.getInfo();
@@ -159,44 +180,31 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   std::vector<geometry_msgs::Pose2D> plan = nav_2d_utils::adjustPlanResolution(global_plan, info.resolution).poses;
 
-  auto planPoseMatchesFinalGoal = [&](const geometry_msgs::Pose2D& plan_pose) {
-    double dx = plan_pose.x - goal.x;
-    double dy = plan_pose.y - goal.y;
+  auto posesDiffer = [&](const geometry_msgs::Pose2D& a, const geometry_msgs::Pose2D& b, double position_tolerance,
+                         double yaw_tolerance) {
+    double dx = a.x - b.x;
+    double dy = a.y - b.y;
     double distance = hypot(dx, dy);
-    if (distance > plan_alignment_position_tolerance_)
+    if (distance > position_tolerance)
     {
-      return false;
+      return true;
     }
 
-    double yaw_error = fabs(angles::shortest_angular_distance(plan_pose.theta, goal.theta));
-    return yaw_error <= plan_alignment_yaw_tolerance_;
+    double yaw_error = fabs(angles::shortest_angular_distance(a.theta, b.theta));
+    return yaw_error > yaw_tolerance;
   };
 
-  bool final_goal_in_plan_window = false;
-  if (!plan.empty())
+  if (plan.empty())
   {
-    final_goal_in_plan_window = planPoseMatchesFinalGoal(plan.back());
+    ROS_ERROR_NAMED("PathProgressCritic", "The adjusted global plan was empty.");
+    return false;
   }
 
-  auto plansEqual = [&](const std::vector<geometry_msgs::Pose2D>& a,
-                        const std::vector<geometry_msgs::Pose2D>& b) {
-    if (a.size() != b.size())
-    {
-      return false;
-    }
-
-    for (size_t idx = 0; idx < a.size(); ++idx)
-    {
-      if (fabs(a[idx].x - b[idx].x) > plan_position_epsilon_ ||
-          fabs(a[idx].y - b[idx].y) > plan_position_epsilon_ ||
-          fabs(angles::shortest_angular_distance(a[idx].theta, b[idx].theta)) > plan_yaw_epsilon_)
-      {
-        return false;
-      }
-    }
-
-    return true;
+  auto planPoseMatchesFinalGoal = [&](const geometry_msgs::Pose2D& plan_pose) {
+    return !posesDiffer(plan_pose, final_goal, plan_alignment_position_tolerance_, plan_alignment_yaw_tolerance_);
   };
+
+  bool final_goal_in_plan_window = planPoseMatchesFinalGoal(plan.back());
 
   auto matchPoseToPlanIndex = [&](const geometry_msgs::Pose2D& pose, unsigned int& index_out) {
     bool found = false;
@@ -229,22 +237,54 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     return found;
   };
 
-  // Reset state if a new global plan arrives (size, geometry, or frame changes)
+  // Reset state if a new global plan arrives (detected via metadata changes or major window shifts)
   bool plan_changed = false;
-  if (!have_last_plan_)
+  geometry_msgs::Pose2D plan_start_pose = plan.front();
+
+  auto headerStampChanged = [&]() {
+    if (last_plan_stamp_.isZero() || global_plan.header.stamp.isZero())
+    {
+      return false;
+    }
+    return last_plan_stamp_ != global_plan.header.stamp;
+  };
+
+  auto headerSeqChanged = [&]() {
+    if (!have_last_plan_)
+    {
+      return false;
+    }
+    return last_plan_seq_ != global_plan.header.seq;
+  };
+
+  auto goalPoseChanged = [&]() {
+    if (!have_last_goal_pose_)
+    {
+      return true;
+    }
+    return posesDiffer(final_goal, last_final_goal_pose_, plan_alignment_position_tolerance_,
+                       plan_alignment_yaw_tolerance_);
+  };
+
+  auto planStartChanged = [&]() {
+    if (!have_last_plan_)
+    {
+      return true;
+    }
+    // Allow the cropped window to slide by a generous distance without counting as a full plan change.
+    double position_tolerance = std::max(plan_alignment_position_tolerance_ * 4.0, plan_alignment_position_tolerance_);
+    return posesDiffer(plan_start_pose, last_plan_start_pose_, position_tolerance, plan_alignment_yaw_tolerance_);
+  };
+
+  if (!have_last_plan_ || global_plan.header.frame_id != last_plan_frame_id_ || headerStampChanged() ||
+      headerSeqChanged() ||
+      goalPoseChanged())
   {
     plan_changed = true;
   }
-  else
+  else if (planStartChanged())
   {
-    if (global_plan.header.frame_id != last_plan_frame_id_)
-    {
-      plan_changed = true;
-    }
-    else if (!plansEqual(plan, last_plan_))
-    {
-      plan_changed = true;
-    }
+    plan_changed = true;
   }
 
   if (plan_changed)
@@ -365,14 +405,11 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   last_plan_end_pose_ = plan.back();
   last_plan_frame_id_ = global_plan.header.frame_id;
   last_plan_stamp_ = global_plan.header.stamp;
-  last_plan_ = plan;
+  last_plan_seq_ = global_plan.header.seq;
+  last_plan_start_pose_ = plan_start_pose;
+  last_final_goal_pose_ = final_goal;
+  have_last_goal_pose_ = true;
 
-
-  if (plan.empty())
-  {
-    ROS_ERROR_NAMED("PathProgressCritic", "The adjusted global plan was empty.");
-    return false;
-  }
 
   unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
 

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -725,14 +725,14 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
                            articulation_indices.end();
   }
 
-  if (!pending_articulation && final_goal_xy_tolerance_ >= 0.0 && plan_last_index <= last_valid_index)
+  if (!pending_articulation && final_goal_xy_tolerance_ >= 0.0 && plan_last_index <= last_valid_index &&
+      goal_index == plan_last_index)
   {
     double final_dx = plan[plan_last_index].x - plan[goal_index].x;
     double final_dy = plan[plan_last_index].y - plan[goal_index].y;
     double final_distance = hypot(final_dx, final_dy);
     if (final_distance <= final_goal_xy_tolerance_)
     {
-      goal_index = plan_last_index;
       goal_yaw = plan[plan_last_index].theta;
       has_forward_direction = false;
     }

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -225,6 +225,10 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     articulation_scan_start = plan_last_index;
   }
 
+  auto articulationSearchStart = [&](unsigned int candidate_start) {
+    return std::max({candidate_start, articulation_scan_start, 1u});
+  };
+
   auto publishIntermediateGoal = [&](const geometry_msgs::Pose2D& goal_pose, double goal_yaw) {
     if (!intermediate_goal_pub_)
     {
@@ -295,7 +299,9 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       unsigned int articulation_index = 0;
       double articulation_yaw = candidate_yaw;
       bool articulation_has_forward = candidate_has_forward;
-      if (findNextArticulation(plan, articulation_scan_start, candidate_index, last_valid_index,
+      unsigned int articulation_start_index = articulationSearchStart(search_index);
+      if (articulation_start_index <= candidate_index &&
+          findNextArticulation(plan, articulation_start_index, candidate_index, last_valid_index,
                                articulation_index, articulation_yaw, articulation_has_forward))
       {
         candidate_index = articulation_index;
@@ -409,7 +415,9 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       unsigned int articulation_index = 0;
       double articulation_yaw = goal_yaw;
       bool articulation_has_forward = has_forward_direction;
-      if (findNextArticulation(plan, articulation_scan_start, goal_index, last_valid_index,
+      unsigned int articulation_start_index = articulationSearchStart(goal_index);
+      if (articulation_start_index <= goal_index &&
+          findNextArticulation(plan, articulation_start_index, goal_index, last_valid_index,
                                articulation_index, articulation_yaw, articulation_has_forward))
       {
         goal_index = articulation_index;

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -208,10 +208,22 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   }
 
   // Constrain the search range to enforce monotonic progress.
-  last_progress_index_ = std::min(last_progress_index_, static_cast<unsigned int>(plan.size() - 1));
+  unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
+  last_progress_index_ = std::min(last_progress_index_, plan_last_index);
 
   unsigned int search_start_index = std::max(start_index, last_progress_index_);
   search_start_index = std::min(search_start_index, last_valid_index);
+
+  unsigned int articulation_scan_start = 0u;
+  if (plan_last_index >= 1)
+  {
+    unsigned int next_index = last_progress_index_ < plan_last_index ? last_progress_index_ + 1 : plan_last_index;
+    articulation_scan_start = std::max(next_index, 1u);
+  }
+  else
+  {
+    articulation_scan_start = plan_last_index;
+  }
 
   auto publishIntermediateGoal = [&](const geometry_msgs::Pose2D& goal_pose, double goal_yaw) {
     if (!intermediate_goal_pub_)
@@ -259,6 +271,11 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
   }
 
+  if (holding_goal_ && held_goal_index_ >= last_progress_index_)
+  {
+    search_start_index = std::min(search_start_index, held_goal_index_);
+  }
+
   unsigned int goal_index = search_start_index;
   double goal_yaw = plan[goal_index].theta;
   bool has_forward_direction = false;
@@ -272,7 +289,26 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     unsigned int candidate_index =
         getGoalIndex(plan, search_index, last_valid_index, candidate_yaw, candidate_has_forward);
 
-    candidate_index = std::max(candidate_index, search_index);
+    bool forced_articulation = false;
+    if (candidate_index > last_progress_index_)
+    {
+      unsigned int articulation_index = 0;
+      double articulation_yaw = candidate_yaw;
+      bool articulation_has_forward = candidate_has_forward;
+      if (findNextArticulation(plan, articulation_scan_start, candidate_index, last_valid_index,
+                               articulation_index, articulation_yaw, articulation_has_forward))
+      {
+        candidate_index = articulation_index;
+        candidate_yaw = articulation_yaw;
+        candidate_has_forward = articulation_has_forward;
+        forced_articulation = true;
+      }
+    }
+
+    if (!forced_articulation)
+    {
+      candidate_index = std::max(candidate_index, search_index);
+    }
 
     if (isGoalReached(robot_pose, plan[candidate_index], candidate_yaw))
     {
@@ -302,7 +338,7 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       continue;
     }
 
-    if (enforce_forward_dot_ && candidate_has_forward)
+    if (enforce_forward_dot_ && candidate_has_forward && !forced_articulation)
     {
       double to_goal_x = plan[candidate_index].x - robot_pose.x;
       double to_goal_y = plan[candidate_index].y - robot_pose.y;
@@ -366,6 +402,20 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     if (!selected_fallback)
     {
       return false;
+    }
+
+    if (goal_index > last_progress_index_)
+    {
+      unsigned int articulation_index = 0;
+      double articulation_yaw = goal_yaw;
+      bool articulation_has_forward = has_forward_direction;
+      if (findNextArticulation(plan, articulation_scan_start, goal_index, last_valid_index,
+                               articulation_index, articulation_yaw, articulation_has_forward))
+      {
+        goal_index = articulation_index;
+        goal_yaw = articulation_yaw;
+        has_forward_direction = articulation_has_forward;
+      }
     }
   }
 
@@ -512,6 +562,78 @@ unsigned int PathProgressCritic::getGoalIndex(const std::vector<geometry_msgs::P
   }
 
   return goal_index;
+}
+
+bool PathProgressCritic::findNextArticulation(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
+                                              unsigned int end_index, unsigned int last_valid_index,
+                                              unsigned int& articulation_index, double& articulation_yaw,
+                                              bool& has_forward_direction) const
+{
+  const double epsilon = 1e-9;
+  articulation_index = 0;
+  articulation_yaw = 0.0;
+  has_forward_direction = false;
+
+  if (plan.size() < 2)
+  {
+    return false;
+  }
+
+  unsigned int clamped_end = std::min(end_index, static_cast<unsigned int>(plan.size() - 1));
+  clamped_end = std::min(clamped_end, last_valid_index);
+  if (clamped_end < 1)
+  {
+    return false;
+  }
+
+  unsigned int scan_start = std::max(start_index, 1u);
+  if (scan_start > clamped_end)
+  {
+    return false;
+  }
+
+  double previous_segment_angle = 0.0;
+  bool previous_segment_angle_set = false;
+  unsigned int previous_segment_end_index = 0;
+
+  for (unsigned int i = scan_start; i <= clamped_end; ++i)
+  {
+    double direction_x = plan[i].x - plan[i - 1].x;
+    double direction_y = plan[i].y - plan[i - 1].y;
+    double length = hypot(direction_x, direction_y);
+    if (length < epsilon)
+    {
+      continue;
+    }
+
+    double current_angle = atan2(direction_y, direction_x);
+
+    if (previous_segment_angle_set)
+    {
+      double articulation_angle = fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
+      if (articulation_angle >= articulation_angle_threshold_)
+      {
+        articulation_index = previous_segment_end_index;
+        articulation_yaw = current_angle;
+        has_forward_direction = true;
+        if (!computeOutgoingAngle(plan, articulation_index, articulation_yaw))
+        {
+          has_forward_direction = false;
+          if (articulation_index == plan.size() - 1)
+          {
+            articulation_yaw = plan[articulation_index].theta;
+          }
+        }
+        return true;
+      }
+    }
+
+    previous_segment_angle = current_angle;
+    previous_segment_angle_set = true;
+    previous_segment_end_index = i;
+  }
+
+  return false;
 }
 
 bool PathProgressCritic::computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -967,6 +967,28 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
   }
 
+  if (plan_last_index <= last_valid_index && goal_index != plan_last_index)
+  {
+    double snap_threshold = final_goal_xy_tolerance_;
+    if (snap_threshold >= 0.0)
+    {
+      double final_dx = plan[plan_last_index].x - plan[goal_index].x;
+      double final_dy = plan[plan_last_index].y - plan[goal_index].y;
+      double distance_to_final = hypot(final_dx, final_dy);
+      if (distance_to_final <= snap_threshold)
+      {
+        ROS_DEBUG_NAMED("PathProgressCritic",
+                        "Snapping intermediate goal index %u to final goal because distance %.3f <= threshold %.3f",
+                        goal_index, distance_to_final, snap_threshold);
+        goal_index = plan_last_index;
+        goal_yaw = plan[plan_last_index].theta;
+        has_forward_direction = false;
+        forced_skipped_articulation = false;
+        has_next_articulation = false;
+      }
+    }
+  }
+
   bool pending_articulation = false;
   if (last_progress_index_ < goal_index)
   {

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -465,27 +465,32 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   bool found_goal = false;
   bool forced_skipped_articulation = false;
 
+  unsigned int next_pending_articulation = 0;
+  double next_pending_articulation_yaw = 0.0;
+  bool next_pending_articulation_has_forward = false;
+  bool has_pending_articulation = false;
+
   if (always_target_articulations_ && !articulation_indices.empty())
   {
-    unsigned int window_start = std::max(search_start_index, last_progress_index_ + 1);
-    unsigned int window_end = last_valid_index;
+    unsigned int articulation_window_start = std::max(search_start_index, last_progress_index_ + 1);
+    unsigned int articulation_window_end = last_valid_index;
 
     for (unsigned int idx : articulation_indices)
     {
-      if (idx < window_start || idx > window_end)
+      if (idx < articulation_window_start || idx > articulation_window_end)
       {
         continue;
       }
 
       double articulation_yaw = plan[idx].theta;
       bool articulation_has_forward = computeOutgoingAngle(plan, idx, articulation_yaw);
-      double goal_candidate_yaw = articulation_has_forward ? articulation_yaw : plan[idx].theta;
+      double articulation_goal_yaw = articulation_has_forward ? articulation_yaw : plan[idx].theta;
 
-      if (isGoalReached(robot_pose, plan[idx], goal_candidate_yaw))
+      if (isGoalReached(robot_pose, plan[idx], articulation_goal_yaw))
       {
         last_progress_index_ = std::max(last_progress_index_, idx);
         geometry_msgs::Pose2D reached_pose = plan[idx];
-        reached_pose.theta = goal_candidate_yaw;
+        reached_pose.theta = articulation_goal_yaw;
         if (reached_intermediate_goals_.empty() ||
             nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
             fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) >
@@ -496,14 +501,10 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         continue;
       }
 
-      goal_index = idx;
-      goal_yaw = goal_candidate_yaw;
-      has_forward_direction = articulation_has_forward;
-      found_goal = true;
-      forced_skipped_articulation = true;
-      ROS_DEBUG_NAMED("PathProgressCritic",
-                      "Selecting articulation index %u as prioritized intermediate goal. last_progress_index_: %u",
-                      goal_index, last_progress_index_);
+      next_pending_articulation = idx;
+      next_pending_articulation_yaw = articulation_goal_yaw;
+      next_pending_articulation_has_forward = articulation_has_forward;
+      has_pending_articulation = true;
       break;
     }
   }
@@ -628,9 +629,40 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       }
     }
 
+    if (has_pending_articulation && candidate_index > next_pending_articulation)
+    {
+      goal_index = next_pending_articulation;
+      goal_yaw = next_pending_articulation_yaw;
+      has_forward_direction = next_pending_articulation_has_forward;
+      found_goal = true;
+      forced_skipped_articulation = true;
+      ROS_DEBUG_NAMED("PathProgressCritic",
+                      "Switching to pending articulation index %u ahead of candidate %u.", goal_index,
+                      candidate_index);
+      break;
+    }
+
     goal_index = candidate_index;
     goal_yaw = candidate_yaw;
     has_forward_direction = candidate_has_forward;
+    found_goal = true;
+    break;
+    if (has_pending_articulation && goal_index > next_pending_articulation)
+    {
+      goal_index = next_pending_articulation;
+      goal_yaw = next_pending_articulation_yaw;
+      has_forward_direction = next_pending_articulation_has_forward;
+      forced_skipped_articulation = true;
+      ROS_DEBUG_NAMED("PathProgressCritic",
+                      "Selecting pending articulation index %u during fallback after candidate %u.", goal_index,
+                      candidate_index);
+    }
+    else
+    {
+      goal_index = candidate_index;
+      goal_yaw = candidate_yaw;
+      has_forward_direction = candidate_has_forward;
+    }
     found_goal = true;
     break;
   }

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -44,6 +44,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <utility>
 #include <vector>
 
 namespace mir_dwb_critics
@@ -119,6 +120,8 @@ void PathProgressCritic::onInit()
   last_plan_.clear();
   plan_position_epsilon_ = 1e-4;
   plan_yaw_epsilon_ = 1e-4;
+  critic_nh_.param("plan_alignment_position_tolerance", plan_alignment_position_tolerance_, 0.15);
+  critic_nh_.param("plan_alignment_yaw_tolerance", plan_alignment_yaw_tolerance_, 3.14159265358979323846);
 }
 
 void PathProgressCritic::reset()
@@ -176,6 +179,37 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     return true;
   };
 
+  auto matchPoseToPlanIndex = [&](const geometry_msgs::Pose2D& pose, unsigned int& index_out) {
+    bool found = false;
+    double best_distance = std::numeric_limits<double>::infinity();
+
+    for (unsigned int idx = 0; idx < plan.size(); ++idx)
+    {
+      double dx = plan[idx].x - pose.x;
+      double dy = plan[idx].y - pose.y;
+      double distance = hypot(dx, dy);
+      if (distance > plan_alignment_position_tolerance_)
+      {
+        continue;
+      }
+
+      double yaw_error = fabs(angles::shortest_angular_distance(plan[idx].theta, pose.theta));
+      if (yaw_error > plan_alignment_yaw_tolerance_)
+      {
+        continue;
+      }
+
+      if (distance < best_distance)
+      {
+        best_distance = distance;
+        index_out = idx;
+        found = true;
+      }
+    }
+
+    return found;
+  };
+
   // Reset state if a new global plan arrives (size, geometry, or frame changes)
   bool plan_changed = false;
   if (!have_last_plan_)
@@ -196,15 +230,93 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   if (plan_changed)
   {
-    // Abort everything and start over
-    reached_intermediate_goals_.clear();
-    last_progress_index_ = 0;
-    holding_goal_ = false;
-    held_goal_index_ = 0;
-    held_goal_pose_.x = 0.0;
-    held_goal_pose_.y = 0.0;
-    held_goal_pose_.theta = 0.0;
-    initial_alignment_done_ = false;
+    bool state_preserved = false;
+    bool progress_match_found = false;
+    unsigned int restored_progress_index = 0u;
+    std::vector<std::pair<unsigned int, geometry_msgs::Pose2D>> preserved_reached;
+    preserved_reached.reserve(reached_intermediate_goals_.size());
+
+    unsigned int previous_progress_index = last_progress_index_;
+
+    for (const auto& reached_pose : reached_intermediate_goals_)
+    {
+      unsigned int matched_index = 0u;
+      if (matchPoseToPlanIndex(reached_pose, matched_index))
+      {
+        geometry_msgs::Pose2D preserved_pose = reached_pose;
+        preserved_pose.x = plan[matched_index].x;
+        preserved_pose.y = plan[matched_index].y;
+        preserved_reached.emplace_back(matched_index, preserved_pose);
+        state_preserved = true;
+        progress_match_found = true;
+        restored_progress_index = std::max(restored_progress_index, matched_index);
+      }
+    }
+
+    unsigned int held_match_index = 0u;
+    if (holding_goal_)
+    {
+      if (matchPoseToPlanIndex(held_goal_pose_, held_match_index))
+      {
+        state_preserved = true;
+        held_goal_index_ = held_match_index;
+        held_goal_pose_.x = plan[held_match_index].x;
+        held_goal_pose_.y = plan[held_match_index].y;
+      }
+      else
+      {
+        holding_goal_ = false;
+        held_goal_index_ = 0u;
+        held_goal_pose_.x = 0.0;
+        held_goal_pose_.y = 0.0;
+        held_goal_pose_.theta = 0.0;
+      }
+    }
+
+    unsigned int robot_match_index = 0u;
+    if (matchPoseToPlanIndex(robot_pose, robot_match_index))
+    {
+      state_preserved = true;
+      progress_match_found = true;
+      restored_progress_index = std::max(restored_progress_index, robot_match_index);
+    }
+
+    if (state_preserved)
+    {
+      if (progress_match_found)
+      {
+        std::sort(preserved_reached.begin(), preserved_reached.end(),
+                  [](const std::pair<unsigned int, geometry_msgs::Pose2D>& lhs,
+                     const std::pair<unsigned int, geometry_msgs::Pose2D>& rhs) {
+                    return lhs.first < rhs.first;
+                  });
+        reached_intermediate_goals_.clear();
+        reached_intermediate_goals_.reserve(preserved_reached.size());
+        for (const auto& entry : preserved_reached)
+        {
+          reached_intermediate_goals_.push_back(entry.second);
+        }
+        unsigned int plan_last_index = plan.empty() ? 0u : static_cast<unsigned int>(plan.size() - 1);
+        last_progress_index_ = std::min(restored_progress_index, plan_last_index);
+      }
+      else
+      {
+        reached_intermediate_goals_.clear();
+        unsigned int plan_last_index = plan.empty() ? 0u : static_cast<unsigned int>(plan.size() - 1);
+        last_progress_index_ = std::min(previous_progress_index, plan_last_index);
+      }
+    }
+    else
+    {
+      reached_intermediate_goals_.clear();
+      last_progress_index_ = 0u;
+      holding_goal_ = false;
+      held_goal_index_ = 0u;
+      held_goal_pose_.x = 0.0;
+      held_goal_pose_.y = 0.0;
+      held_goal_pose_.theta = 0.0;
+      initial_alignment_done_ = false;
+    }
 
     have_last_plan_ = true;
   }

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -87,6 +87,7 @@ void PathProgressCritic::onInit()
   critic_nh_.param("heading_scale", heading_scale_, 1.0);
   critic_nh_.param("enforce_forward_dot", enforce_forward_dot_, true);
   critic_nh_.param("always_target_articulations", always_target_articulations_, true);
+  initial_alignment_done_ = false;
 
   intermediate_goal_pub_ = critic_nh_.advertise<geometry_msgs::PoseStamped>("intermediate_goal", 1);
   articulation_points_pub_ = critic_nh_.advertise<sensor_msgs::PointCloud>("articulation_points", 1);
@@ -119,6 +120,7 @@ void PathProgressCritic::reset()
   held_goal_pose_.x = 0.0;
   held_goal_pose_.y = 0.0;
   held_goal_pose_.theta = 0.0;
+  initial_alignment_done_ = false;
 }
 
 double PathProgressCritic::scoreTrajectory(const dwb_msgs::Trajectory2D& traj)
@@ -151,6 +153,34 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   }
 
   const unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
+
+  if (!initial_alignment_done_)
+  {
+    double desired_initial_yaw = plan.front().theta;
+    bool reached_alignment = isGoalReached(robot_pose, plan.front(), desired_initial_yaw);
+    if (!reached_alignment)
+    {
+      unsigned int initial_x = 0;
+      unsigned int initial_y = 0;
+      if (worldToGridBounded(info, plan.front().x, plan.front().y, initial_x, initial_y))
+      {
+        x = initial_x;
+        y = initial_y;
+        desired_angle = desired_initial_yaw;
+        held_goal_pose_ = plan.front();
+        held_goal_pose_.theta = desired_initial_yaw;
+        held_goal_index_ = 0;
+        holding_goal_ = true;
+        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
+        ROS_DEBUG_NAMED("PathProgressCritic",
+                        "Holding initial alignment goal at plan index 0 (x: %.3f, y: %.3f, yaw: %.3f rad)",
+                        held_goal_pose_.x, held_goal_pose_.y, held_goal_pose_.theta);
+        return true;
+      }
+    }
+
+    initial_alignment_done_ = true;
+  }
 
   if (holding_goal_ && held_goal_index_ >= plan.size())
   {

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -116,6 +116,9 @@ void PathProgressCritic::onInit()
   last_plan_end_pose_.theta = 0.0;
   last_plan_frame_id_.clear();
   last_plan_stamp_ = ros::Time(0);
+  last_plan_.clear();
+  plan_position_epsilon_ = 1e-4;
+  plan_yaw_epsilon_ = 1e-4;
 }
 
 void PathProgressCritic::reset()
@@ -152,7 +155,28 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   }
 
   std::vector<geometry_msgs::Pose2D> plan = nav_2d_utils::adjustPlanResolution(global_plan, info.resolution).poses;
-  // Reset state if a new global plan arrives (size, last pose, frame or stamp changes)
+
+  auto plansEqual = [&](const std::vector<geometry_msgs::Pose2D>& a,
+                        const std::vector<geometry_msgs::Pose2D>& b) {
+    if (a.size() != b.size())
+    {
+      return false;
+    }
+
+    for (size_t idx = 0; idx < a.size(); ++idx)
+    {
+      if (fabs(a[idx].x - b[idx].x) > plan_position_epsilon_ ||
+          fabs(a[idx].y - b[idx].y) > plan_position_epsilon_ ||
+          fabs(angles::shortest_angular_distance(a[idx].theta, b[idx].theta)) > plan_yaw_epsilon_)
+      {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  // Reset state if a new global plan arrives (size, geometry, or frame changes)
   bool plan_changed = false;
   if (!have_last_plan_)
   {
@@ -160,12 +184,11 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   }
   else
   {
-    if (last_plan_size_ != plan.size()) plan_changed = true;
-    if (global_plan.header.frame_id != last_plan_frame_id_) plan_changed = true;
-    if (global_plan.header.stamp != last_plan_stamp_) plan_changed = true;
-    const geometry_msgs::Pose2D& end_pose = plan.back();
-    if (fabs(end_pose.x - last_plan_end_pose_.x) > 1e-6 || fabs(end_pose.y - last_plan_end_pose_.y) > 1e-6 ||
-        fabs(angles::shortest_angular_distance(end_pose.theta, last_plan_end_pose_.theta)) > 1e-6)
+    if (global_plan.header.frame_id != last_plan_frame_id_)
+    {
+      plan_changed = true;
+    }
+    else if (!plansEqual(plan, last_plan_))
     {
       plan_changed = true;
     }
@@ -184,11 +207,13 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     initial_alignment_done_ = false;
 
     have_last_plan_ = true;
-    last_plan_size_ = plan.size();
-    last_plan_end_pose_ = plan.back();
-    last_plan_frame_id_ = global_plan.header.frame_id;
-    last_plan_stamp_ = global_plan.header.stamp;
   }
+
+  last_plan_size_ = plan.size();
+  last_plan_end_pose_ = plan.back();
+  last_plan_frame_id_ = global_plan.header.frame_id;
+  last_plan_stamp_ = global_plan.header.stamp;
+  last_plan_ = plan;
 
 
   if (plan.empty())

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -401,9 +401,53 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   double goal_yaw = plan[goal_index].theta;
   bool has_forward_direction = false;
   bool found_goal = false;
+  bool forced_skipped_articulation = false;
+
+  if (search_start_index > last_progress_index_ + 1 && !articulation_indices.empty())
+  {
+    unsigned int articulation_lower_bound = std::max(last_progress_index_ + 1, 1u);
+    unsigned int articulation_upper_bound = std::min(search_start_index - 1, last_valid_index);
+
+    if (articulation_lower_bound <= articulation_upper_bound)
+    {
+      auto articulation_it = std::find_if(articulation_indices.begin(), articulation_indices.end(),
+                                          [&](unsigned int index) {
+                                            return index >= articulation_lower_bound && index <= articulation_upper_bound;
+                                          });
+
+      if (articulation_it != articulation_indices.end())
+      {
+        goal_index = *articulation_it;
+        has_forward_direction = computeOutgoingAngle(plan, goal_index, goal_yaw);
+        if (!has_forward_direction)
+        {
+          goal_yaw = plan[goal_index].theta;
+        }
+
+        if (enforce_forward_dot_ && has_forward_direction)
+        {
+          double to_goal_x = plan[goal_index].x - robot_pose.x;
+          double to_goal_y = plan[goal_index].y - robot_pose.y;
+          double dot = to_goal_x * std::cos(goal_yaw) + to_goal_y * std::sin(goal_yaw);
+          if (dot < 0.0)
+          {
+            ROS_WARN_NAMED("PathProgressCritic",
+                           "Forcing skipped articulation index %u despite backward dot product %.3f due to policy.",
+                           goal_index, dot);
+          }
+        }
+
+        forced_skipped_articulation = true;
+        found_goal = true;
+        ROS_DEBUG_NAMED("PathProgressCritic",
+                        "Recovered skipped articulation index %u between progress %u and search start %u.",
+                        goal_index, last_progress_index_, search_start_index);
+      }
+    }
+  }
 
   unsigned int search_index = search_start_index;
-  while (search_index <= last_valid_index)
+  while (!forced_skipped_articulation && search_index <= last_valid_index)
   {
     double candidate_yaw = goal_yaw;
     bool candidate_has_forward = false;

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -464,13 +464,12 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   bool has_forward_direction = false;
   bool found_goal = false;
   bool forced_skipped_articulation = false;
+  unsigned int next_articulation_index = 0;
+  double next_articulation_yaw = 0.0;
+  bool next_articulation_has_forward = false;
+  bool has_next_articulation = false;
 
-  unsigned int next_pending_articulation = 0;
-  double next_pending_articulation_yaw = 0.0;
-  bool next_pending_articulation_has_forward = false;
-  bool has_pending_articulation = false;
-
-  if (always_target_articulations_ && !articulation_indices.empty())
+  if (initial_alignment_done_ && !articulation_indices.empty())
   {
     unsigned int articulation_window_start = std::max(search_start_index, last_progress_index_ + 1);
     unsigned int articulation_window_end = last_valid_index;
@@ -501,10 +500,10 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         continue;
       }
 
-      next_pending_articulation = idx;
-      next_pending_articulation_yaw = articulation_goal_yaw;
-      next_pending_articulation_has_forward = articulation_has_forward;
-      has_pending_articulation = true;
+      next_articulation_index = idx;
+      next_articulation_yaw = articulation_goal_yaw;
+      next_articulation_has_forward = articulation_has_forward;
+      has_next_articulation = true;
       break;
     }
   }
@@ -583,6 +582,20 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       candidate_index = std::max(candidate_index, search_index);
     }
 
+    if (has_next_articulation && candidate_index >= next_articulation_index)
+    {
+      goal_index = next_articulation_index;
+      goal_yaw = next_articulation_yaw;
+      has_forward_direction = next_articulation_has_forward;
+      found_goal = true;
+      forced_skipped_articulation = true;
+      has_next_articulation = false;
+      ROS_DEBUG_NAMED("PathProgressCritic",
+                      "Selecting pending articulation index %u reached at candidate %u.", goal_index,
+                      candidate_index);
+      break;
+    }
+
     if (isGoalReached(robot_pose, plan[candidate_index], candidate_yaw))
     {
       last_progress_index_ = std::max(last_progress_index_, candidate_index);
@@ -629,40 +642,9 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       }
     }
 
-    if (has_pending_articulation && candidate_index > next_pending_articulation)
-    {
-      goal_index = next_pending_articulation;
-      goal_yaw = next_pending_articulation_yaw;
-      has_forward_direction = next_pending_articulation_has_forward;
-      found_goal = true;
-      forced_skipped_articulation = true;
-      ROS_DEBUG_NAMED("PathProgressCritic",
-                      "Switching to pending articulation index %u ahead of candidate %u.", goal_index,
-                      candidate_index);
-      break;
-    }
-
     goal_index = candidate_index;
     goal_yaw = candidate_yaw;
     has_forward_direction = candidate_has_forward;
-    found_goal = true;
-    break;
-    if (has_pending_articulation && goal_index > next_pending_articulation)
-    {
-      goal_index = next_pending_articulation;
-      goal_yaw = next_pending_articulation_yaw;
-      has_forward_direction = next_pending_articulation_has_forward;
-      forced_skipped_articulation = true;
-      ROS_DEBUG_NAMED("PathProgressCritic",
-                      "Selecting pending articulation index %u during fallback after candidate %u.", goal_index,
-                      candidate_index);
-    }
-    else
-    {
-      goal_index = candidate_index;
-      goal_yaw = candidate_yaw;
-      has_forward_direction = candidate_has_forward;
-    }
     found_goal = true;
     break;
   }
@@ -706,6 +688,17 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     if (!selected_fallback)
     {
       return false;
+    }
+
+    if (has_next_articulation && goal_index >= next_articulation_index)
+    {
+      goal_index = next_articulation_index;
+      goal_yaw = next_articulation_yaw;
+      has_forward_direction = next_articulation_has_forward;
+      has_next_articulation = false;
+      forced_skipped_articulation = true;
+      ROS_DEBUG_NAMED("PathProgressCritic",
+                      "Fallback switching to pending articulation index %u.", goal_index);
     }
 
     if (goal_index > last_progress_index_)

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -197,7 +197,31 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     return false;
   }
 
-  const unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
+  unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
+
+  if (initial_alignment_done_ && plan.size() > 1 && last_progress_index_ > 0)
+  {
+    unsigned int prune_limit = std::min(last_progress_index_, plan_last_index);
+    if (prune_limit > 0)
+    {
+      plan.erase(plan.begin(), plan.begin() + prune_limit);
+      last_progress_index_ = last_progress_index_ >= prune_limit ? last_progress_index_ - prune_limit : 0;
+      plan_last_index = static_cast<unsigned int>(plan.size() - 1);
+
+      if (holding_goal_)
+      {
+        if (held_goal_index_ < prune_limit)
+        {
+          holding_goal_ = false;
+          held_goal_index_ = 0;
+        }
+        else
+        {
+          held_goal_index_ -= prune_limit;
+        }
+      }
+    }
+  }
 
   if (holding_goal_ && held_goal_index_ >= plan.size())
   {

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -77,6 +77,10 @@ void PathProgressCritic::onInit()
   {
     critic_nh_.param("yaw_goal_tolerance", final_goal_yaw_tolerance_, yaw_local_goal_tolerance_);
   }
+  if (!private_nh.getParam("xy_goal_tolerance", final_goal_xy_tolerance_))
+  {
+    critic_nh_.param("xy_goal_tolerance", final_goal_xy_tolerance_, xy_local_goal_tolerance_);
+  }
   critic_nh_.param("angle_threshold", angle_threshold_, M_PI_4);
   critic_nh_.param("articulation_angle_threshold", articulation_angle_threshold_, 1.3089969389957472);
   critic_nh_.param("heading_scale", heading_scale_, 1.0);
@@ -99,6 +103,7 @@ void PathProgressCritic::onInit()
   hold_position_epsilon_ = 1e-6;
   hold_yaw_epsilon_ = 1e-6;
   final_goal_yaw_tolerance_ = std::max(final_goal_yaw_tolerance_, 1e-6);
+  final_goal_xy_tolerance_ = std::max(final_goal_xy_tolerance_, 0.0);
 }
 
 void PathProgressCritic::reset()
@@ -536,6 +541,26 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
         goal_yaw = articulation_yaw;
         has_forward_direction = articulation_has_forward;
       }
+    }
+  }
+
+  bool pending_articulation = false;
+  if (last_progress_index_ < goal_index)
+  {
+    pending_articulation = std::find(articulation_indices.begin(), articulation_indices.end(), goal_index) !=
+                           articulation_indices.end();
+  }
+
+  if (!pending_articulation && final_goal_xy_tolerance_ >= 0.0 && plan_last_index <= last_valid_index)
+  {
+    double final_dx = plan[plan_last_index].x - plan[goal_index].x;
+    double final_dy = plan[plan_last_index].y - plan[goal_index].y;
+    double final_distance = hypot(final_dx, final_dy);
+    if (final_distance <= final_goal_xy_tolerance_)
+    {
+      goal_index = plan_last_index;
+      goal_yaw = plan[plan_last_index].theta;
+      has_forward_direction = false;
     }
   }
 

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -331,7 +331,7 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       marker.pose.orientation.y = 0.0;
       marker.pose.orientation.z = 0.0;
       marker.pose.orientation.w = 1.0;
-      double diameter = std::max(2.0 * final_goal_xy_tolerance_, 1e-6);
+      double diameter = std::max(2.0 * xy_local_goal_tolerance_, 1e-6);
       marker.scale.x = diameter;
       marker.scale.y = diameter;
       marker.scale.z = diameter;

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -154,34 +154,6 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   const unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
 
-  if (!initial_alignment_done_)
-  {
-    double desired_initial_yaw = plan.front().theta;
-    bool reached_alignment = isGoalReached(robot_pose, plan.front(), desired_initial_yaw);
-    if (!reached_alignment)
-    {
-      unsigned int initial_x = 0;
-      unsigned int initial_y = 0;
-      if (worldToGridBounded(info, plan.front().x, plan.front().y, initial_x, initial_y))
-      {
-        x = initial_x;
-        y = initial_y;
-        desired_angle = desired_initial_yaw;
-        held_goal_pose_ = plan.front();
-        held_goal_pose_.theta = desired_initial_yaw;
-        held_goal_index_ = 0;
-        holding_goal_ = true;
-        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
-        ROS_DEBUG_NAMED("PathProgressCritic",
-                        "Holding initial alignment goal at plan index 0 (x: %.3f, y: %.3f, yaw: %.3f rad)",
-                        held_goal_pose_.x, held_goal_pose_.y, held_goal_pose_.theta);
-        return true;
-      }
-    }
-
-    initial_alignment_done_ = true;
-  }
-
   if (holding_goal_ && held_goal_index_ >= plan.size())
   {
     ROS_DEBUG_NAMED("PathProgressCritic", "Held goal index %u is out of range for current plan of size %zu. Releasing hold.",
@@ -375,6 +347,34 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
       intermediate_goal_tolerance_pub_.publish(marker_array);
     }
   };
+
+  if (!initial_alignment_done_)
+  {
+    double desired_initial_yaw = plan.front().theta;
+    bool reached_alignment = isGoalReached(robot_pose, plan.front(), desired_initial_yaw);
+    if (!reached_alignment)
+    {
+      unsigned int initial_x = 0;
+      unsigned int initial_y = 0;
+      if (worldToGridBounded(info, plan.front().x, plan.front().y, initial_x, initial_y))
+      {
+        x = initial_x;
+        y = initial_y;
+        desired_angle = desired_initial_yaw;
+        held_goal_pose_ = plan.front();
+        held_goal_pose_.theta = desired_initial_yaw;
+        held_goal_index_ = 0;
+        holding_goal_ = true;
+        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
+        ROS_DEBUG_NAMED("PathProgressCritic",
+                        "Holding initial alignment goal at plan index 0 (x: %.3f, y: %.3f, yaw: %.3f rad)",
+                        held_goal_pose_.x, held_goal_pose_.y, held_goal_pose_.theta);
+        return true;
+      }
+    }
+
+    initial_alignment_done_ = true;
+  }
 
   std::vector<unsigned int> articulation_indices = collectArticulationIndices(1u, plan_last_index);
   publishArticulationPointCloud(articulation_indices);

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -109,6 +109,13 @@ void PathProgressCritic::onInit()
   hold_yaw_epsilon_ = 1e-6;
   final_goal_yaw_tolerance_ = std::max(final_goal_yaw_tolerance_, 1e-6);
   final_goal_xy_tolerance_ = std::max(final_goal_xy_tolerance_, 0.0);
+  have_last_plan_ = false;
+  last_plan_size_ = 0;
+  last_plan_end_pose_.x = 0.0;
+  last_plan_end_pose_.y = 0.0;
+  last_plan_end_pose_.theta = 0.0;
+  last_plan_frame_id_.clear();
+  last_plan_stamp_ = ros::Time(0);
 }
 
 void PathProgressCritic::reset()
@@ -145,6 +152,44 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   }
 
   std::vector<geometry_msgs::Pose2D> plan = nav_2d_utils::adjustPlanResolution(global_plan, info.resolution).poses;
+  // Reset state if a new global plan arrives (size, last pose, frame or stamp changes)
+  bool plan_changed = false;
+  if (!have_last_plan_)
+  {
+    plan_changed = true;
+  }
+  else
+  {
+    if (last_plan_size_ != plan.size()) plan_changed = true;
+    if (global_plan.header.frame_id != last_plan_frame_id_) plan_changed = true;
+    if (global_plan.header.stamp != last_plan_stamp_) plan_changed = true;
+    const geometry_msgs::Pose2D& end_pose = plan.back();
+    if (fabs(end_pose.x - last_plan_end_pose_.x) > 1e-6 || fabs(end_pose.y - last_plan_end_pose_.y) > 1e-6 ||
+        fabs(angles::shortest_angular_distance(end_pose.theta, last_plan_end_pose_.theta)) > 1e-6)
+    {
+      plan_changed = true;
+    }
+  }
+
+  if (plan_changed)
+  {
+    // Abort everything and start over
+    reached_intermediate_goals_.clear();
+    last_progress_index_ = 0;
+    holding_goal_ = false;
+    held_goal_index_ = 0;
+    held_goal_pose_.x = 0.0;
+    held_goal_pose_.y = 0.0;
+    held_goal_pose_.theta = 0.0;
+    initial_alignment_done_ = false;
+
+    have_last_plan_ = true;
+    last_plan_size_ = plan.size();
+    last_plan_end_pose_ = plan.back();
+    last_plan_frame_id_ = global_plan.header.frame_id;
+    last_plan_stamp_ = global_plan.header.stamp;
+  }
+
 
   if (plan.empty())
   {
@@ -351,24 +396,25 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   if (!initial_alignment_done_)
   {
     double desired_initial_yaw = plan.front().theta;
-    bool reached_alignment = isGoalReached(robot_pose, plan.front(), desired_initial_yaw);
-    if (!reached_alignment)
+    double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, desired_initial_yaw));
+    if (yaw_error >= yaw_local_goal_tolerance_)
     {
-      unsigned int initial_x = 0;
-      unsigned int initial_y = 0;
-      if (worldToGridBounded(info, plan.front().x, plan.front().y, initial_x, initial_y))
+      unsigned int rx = 0;
+      unsigned int ry = 0;
+      if (worldToGridBounded(info, robot_pose.x, robot_pose.y, rx, ry))
       {
-        x = initial_x;
-        y = initial_y;
+        x = rx;
+        y = ry;
         desired_angle = desired_initial_yaw;
-        held_goal_pose_ = plan.front();
+        held_goal_pose_.x = robot_pose.x;
+        held_goal_pose_.y = robot_pose.y;
         held_goal_pose_.theta = desired_initial_yaw;
         held_goal_index_ = 0;
         holding_goal_ = true;
         publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
         ROS_DEBUG_NAMED("PathProgressCritic",
-                        "Holding initial alignment goal at plan index 0 (x: %.3f, y: %.3f, yaw: %.3f rad)",
-                        held_goal_pose_.x, held_goal_pose_.y, held_goal_pose_.theta);
+                        "Initial alignment: rotate in place to yaw %.3f rad at robot pose (x: %.3f, y: %.3f)",
+                        held_goal_pose_.theta, held_goal_pose_.x, held_goal_pose_.y);
         return true;
       }
     }
@@ -508,7 +554,8 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
   }
 
-  if (!found_goal && search_start_index > last_progress_index_ + 1 && !articulation_indices.empty())
+  if (!found_goal && initial_alignment_done_ && search_start_index > last_progress_index_ + 1 &&
+      !articulation_indices.empty())
   {
     unsigned int articulation_lower_bound = std::max(last_progress_index_ + 1, 1u);
     unsigned int articulation_upper_bound = std::min(search_start_index - 1, last_valid_index);
@@ -725,6 +772,8 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
                            articulation_indices.end();
   }
 
+  // Only consider snapping to the final goal yaw when we have already selected the last path index as goal.
+  // Otherwise, keep following the path even if the final goal is within tolerance.
   if (!pending_articulation && final_goal_xy_tolerance_ >= 0.0 && plan_last_index <= last_valid_index &&
       goal_index == plan_last_index)
   {

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -32,19 +32,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <mir_dwb_critics/path_progress.h>
-#include <angles/angles.h>
 #include <nav_grid/coordinate_conversion.h>
 #include <pluginlib/class_list_macros.h>
 #include <nav_2d_utils/path_ops.h>
-#include <sensor_msgs/PointCloud.h>
-#include <visualization_msgs/MarkerArray.h>
-#include <ros/node_handle.h>
-#include <ros/time.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <algorithm>
-#include <cmath>
-#include <limits>
-#include <utility>
 #include <vector>
 
 namespace mir_dwb_critics
@@ -55,7 +45,7 @@ bool PathProgressCritic::prepare(const geometry_msgs::Pose2D& pose, const nav_2d
   dwb_critics::MapGridCritic::reset();
 
   unsigned int local_goal_x, local_goal_y;
-  if (!getGoalPose(pose, goal, global_plan, local_goal_x, local_goal_y, desired_angle_))
+  if (!getGoalPose(pose, global_plan, local_goal_x, local_goal_y, desired_angle_))
   {
     return false;
   }
@@ -73,101 +63,29 @@ void PathProgressCritic::onInit()
 {
   dwb_critics::MapGridCritic::onInit();
   critic_nh_.param("xy_local_goal_tolerance", xy_local_goal_tolerance_, 0.20);
-  critic_nh_.param("yaw_local_goal_tolerance", yaw_local_goal_tolerance_, 0.15);
-  ros::NodeHandle private_nh("~");
-  if (!private_nh.getParam("yaw_goal_tolerance", final_goal_yaw_tolerance_))
-  {
-    critic_nh_.param("yaw_goal_tolerance", final_goal_yaw_tolerance_, yaw_local_goal_tolerance_);
-  }
-  if (!private_nh.getParam("xy_goal_tolerance", final_goal_xy_tolerance_))
-  {
-    critic_nh_.param("xy_goal_tolerance", final_goal_xy_tolerance_, xy_local_goal_tolerance_);
-  }
   critic_nh_.param("angle_threshold", angle_threshold_, M_PI_4);
-  critic_nh_.param("articulation_angle_threshold", articulation_angle_threshold_, 1.3089969389957472);
   critic_nh_.param("heading_scale", heading_scale_, 1.0);
-  critic_nh_.param("enforce_forward_dot", enforce_forward_dot_, true);
-  critic_nh_.param("always_target_articulations", always_target_articulations_, true);
-  initial_alignment_done_ = false;
-
-  intermediate_goal_pub_ = critic_nh_.advertise<geometry_msgs::PoseStamped>("intermediate_goal", 1);
-  articulation_points_pub_ = critic_nh_.advertise<sensor_msgs::PointCloud>("articulation_points", 1);
-  intermediate_goal_tolerance_pub_ =
-      critic_nh_.advertise<visualization_msgs::MarkerArray>("intermediate_goal_tolerance", 1);
-
-  articulation_angle_threshold_ = std::max(articulation_angle_threshold_, angle_threshold_);
 
   // divide heading scale by position scale because the sum will be multiplied by scale again
   heading_scale_ /= getScale();
-  last_progress_index_ = 0;
-  reached_intermediate_goals_.clear();
-  holding_goal_ = false;
-  held_goal_index_ = 0;
-  held_goal_pose_.x = 0.0;
-  held_goal_pose_.y = 0.0;
-  held_goal_pose_.theta = 0.0;
-  hold_position_epsilon_ = 1e-6;
-  hold_yaw_epsilon_ = 1e-6;
-  final_goal_yaw_tolerance_ = std::max(final_goal_yaw_tolerance_, 1e-6);
-  final_goal_xy_tolerance_ = std::max(final_goal_xy_tolerance_, 0.0);
-  have_last_plan_ = false;
-  last_plan_size_ = 0;
-  last_plan_end_pose_.x = 0.0;
-  last_plan_end_pose_.y = 0.0;
-  last_plan_end_pose_.theta = 0.0;
-  last_plan_frame_id_.clear();
-  last_plan_stamp_ = ros::Time(0);
-  last_plan_seq_ = 0u;
-  last_plan_start_pose_.x = 0.0;
-  last_plan_start_pose_.y = 0.0;
-  last_plan_start_pose_.theta = 0.0;
-  last_final_goal_pose_.x = 0.0;
-  last_final_goal_pose_.y = 0.0;
-  last_final_goal_pose_.theta = 0.0;
-  have_last_goal_pose_ = false;
-  critic_nh_.param("plan_alignment_position_tolerance", plan_alignment_position_tolerance_, 0.15);
-  critic_nh_.param("plan_alignment_yaw_tolerance", plan_alignment_yaw_tolerance_, 3.14159265358979323846);
 }
 
 void PathProgressCritic::reset()
 {
   reached_intermediate_goals_.clear();
-  last_progress_index_ = 0;
-  holding_goal_ = false;
-  held_goal_index_ = 0;
-  held_goal_pose_.x = 0.0;
-  held_goal_pose_.y = 0.0;
-  held_goal_pose_.theta = 0.0;
-  initial_alignment_done_ = false;
-  have_last_plan_ = false;
-  last_plan_size_ = 0;
-  last_plan_end_pose_.x = 0.0;
-  last_plan_end_pose_.y = 0.0;
-  last_plan_end_pose_.theta = 0.0;
-  last_plan_frame_id_.clear();
-  last_plan_stamp_ = ros::Time(0);
-  last_plan_seq_ = 0u;
-  last_plan_start_pose_.x = 0.0;
-  last_plan_start_pose_.y = 0.0;
-  last_plan_start_pose_.theta = 0.0;
-  last_final_goal_pose_.x = 0.0;
-  last_final_goal_pose_.y = 0.0;
-  last_final_goal_pose_.theta = 0.0;
-  have_last_goal_pose_ = false;
 }
 
 double PathProgressCritic::scoreTrajectory(const dwb_msgs::Trajectory2D& traj)
 {
   double position_score = MapGridCritic::scoreTrajectory(traj);
-  double heading_diff = fabs(angles::shortest_angular_distance(traj.poses.back().theta, desired_angle_));
+  double heading_diff = fabs(remainder(traj.poses.back().theta - desired_angle_, 2 * M_PI));
   double heading_score = heading_diff * heading_diff;
 
   return position_score + heading_scale_ * heading_score;
 }
 
-bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& final_goal,
-                                     const nav_2d_msgs::Path2D& global_plan, unsigned int& x, unsigned int& y,
-                                     double& desired_angle)
+bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, const nav_2d_msgs::Path2D& global_plan,
+                                     unsigned int& x, unsigned int& y, double& desired_angle)
 {
   const nav_core2::Costmap& costmap = *costmap_;
   const nav_grid::NavGridInfo& info = costmap.getInfo();
@@ -179,271 +97,6 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   }
 
   std::vector<geometry_msgs::Pose2D> plan = nav_2d_utils::adjustPlanResolution(global_plan, info.resolution).poses;
-
-  auto posesDiffer = [&](const geometry_msgs::Pose2D& a, const geometry_msgs::Pose2D& b, double position_tolerance,
-                         double yaw_tolerance) {
-    double dx = a.x - b.x;
-    double dy = a.y - b.y;
-    double distance = hypot(dx, dy);
-    if (distance > position_tolerance)
-    {
-      return true;
-    }
-
-    double yaw_error = fabs(angles::shortest_angular_distance(a.theta, b.theta));
-    return yaw_error > yaw_tolerance;
-  };
-
-  if (plan.empty())
-  {
-    ROS_ERROR_NAMED("PathProgressCritic", "The adjusted global plan was empty.");
-    return false;
-  }
-
-  auto planPoseMatchesFinalGoal = [&](const geometry_msgs::Pose2D& plan_pose) {
-    return !posesDiffer(plan_pose, final_goal, plan_alignment_position_tolerance_, plan_alignment_yaw_tolerance_);
-  };
-
-  bool final_goal_in_plan_window = planPoseMatchesFinalGoal(plan.back());
-
-  auto matchPoseToPlanIndex = [&](const geometry_msgs::Pose2D& pose, unsigned int& index_out) {
-    bool found = false;
-    double best_distance = std::numeric_limits<double>::infinity();
-
-    for (unsigned int idx = 0; idx < plan.size(); ++idx)
-    {
-      double dx = plan[idx].x - pose.x;
-      double dy = plan[idx].y - pose.y;
-      double distance = hypot(dx, dy);
-      if (distance > plan_alignment_position_tolerance_)
-      {
-        continue;
-      }
-
-      double yaw_error = fabs(angles::shortest_angular_distance(plan[idx].theta, pose.theta));
-      if (yaw_error > plan_alignment_yaw_tolerance_)
-      {
-        continue;
-      }
-
-      if (distance < best_distance)
-      {
-        best_distance = distance;
-        index_out = idx;
-        found = true;
-      }
-    }
-
-    return found;
-  };
-
-  // Reset state if a new global plan arrives (detected via metadata changes or major window shifts)
-  bool plan_changed = false;
-  geometry_msgs::Pose2D plan_start_pose = plan.front();
-
-  auto headerStampChanged = [&]() {
-    if (last_plan_stamp_.isZero() || global_plan.header.stamp.isZero())
-    {
-      return false;
-    }
-    return last_plan_stamp_ != global_plan.header.stamp;
-  };
-
-  auto headerSeqChanged = [&]() {
-    if (!have_last_plan_)
-    {
-      return false;
-    }
-    return last_plan_seq_ != global_plan.header.seq;
-  };
-
-  auto goalPoseChanged = [&]() {
-    if (!have_last_goal_pose_)
-    {
-      return true;
-    }
-    return posesDiffer(final_goal, last_final_goal_pose_, plan_alignment_position_tolerance_,
-                       plan_alignment_yaw_tolerance_);
-  };
-
-  auto planStartChanged = [&]() {
-    if (!have_last_plan_)
-    {
-      return true;
-    }
-    // Allow the cropped window to slide by a generous distance without counting as a full plan change.
-    double position_tolerance = std::max(plan_alignment_position_tolerance_ * 4.0, plan_alignment_position_tolerance_);
-    return posesDiffer(plan_start_pose, last_plan_start_pose_, position_tolerance, plan_alignment_yaw_tolerance_);
-  };
-
-  if (!have_last_plan_ || global_plan.header.frame_id != last_plan_frame_id_ || headerStampChanged() ||
-      headerSeqChanged() ||
-      goalPoseChanged())
-  {
-    plan_changed = true;
-  }
-  else if (planStartChanged())
-  {
-    plan_changed = true;
-  }
-
-  if (plan_changed)
-  {
-    bool state_preserved = false;
-    bool progress_match_found = false;
-    unsigned int restored_progress_index = 0u;
-    std::vector<std::pair<unsigned int, geometry_msgs::Pose2D>> preserved_reached;
-    preserved_reached.reserve(reached_intermediate_goals_.size());
-
-    unsigned int previous_progress_index = last_progress_index_;
-
-    for (const auto& reached_pose : reached_intermediate_goals_)
-    {
-      unsigned int matched_index = 0u;
-      if (matchPoseToPlanIndex(reached_pose, matched_index))
-      {
-        geometry_msgs::Pose2D preserved_pose = reached_pose;
-        preserved_pose.x = plan[matched_index].x;
-        preserved_pose.y = plan[matched_index].y;
-        preserved_reached.emplace_back(matched_index, preserved_pose);
-        state_preserved = true;
-        progress_match_found = true;
-        restored_progress_index = std::max(restored_progress_index, matched_index);
-      }
-    }
-
-    unsigned int held_match_index = 0u;
-    if (holding_goal_)
-    {
-      if (matchPoseToPlanIndex(held_goal_pose_, held_match_index))
-      {
-        state_preserved = true;
-        held_goal_index_ = held_match_index;
-        held_goal_pose_.x = plan[held_match_index].x;
-        held_goal_pose_.y = plan[held_match_index].y;
-      }
-      else
-      {
-        holding_goal_ = false;
-        held_goal_index_ = 0u;
-        held_goal_pose_.x = 0.0;
-        held_goal_pose_.y = 0.0;
-        held_goal_pose_.theta = 0.0;
-      }
-    }
-
-    unsigned int robot_match_index = 0u;
-    if (matchPoseToPlanIndex(robot_pose, robot_match_index))
-    {
-      state_preserved = true;
-
-      double match_goal_yaw = plan[robot_match_index].theta;
-      if (!computeOutgoingAngle(plan, robot_match_index, match_goal_yaw))
-      {
-        match_goal_yaw = plan[robot_match_index].theta;
-      }
-
-      bool match_is_final_index = ((robot_match_index + 1u) >= plan.size()) && final_goal_in_plan_window;
-      double match_yaw_tolerance = match_is_final_index ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
-      double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, match_goal_yaw));
-
-      if (yaw_error <= match_yaw_tolerance)
-      {
-        progress_match_found = true;
-        restored_progress_index = std::max(restored_progress_index, robot_match_index);
-      }
-      else
-      {
-        ROS_DEBUG_NAMED("PathProgressCritic",
-                        "Robot pose matched plan index %u but yaw error %.3f rad exceeds tolerance %.3f."
-                        " Preserving state without increasing progress.",
-                        robot_match_index, yaw_error, match_yaw_tolerance);
-      }
-    }
-
-    if (state_preserved)
-    {
-      if (progress_match_found)
-      {
-        std::sort(preserved_reached.begin(), preserved_reached.end(),
-                  [](const std::pair<unsigned int, geometry_msgs::Pose2D>& lhs,
-                     const std::pair<unsigned int, geometry_msgs::Pose2D>& rhs) {
-                    return lhs.first < rhs.first;
-                  });
-        reached_intermediate_goals_.clear();
-        reached_intermediate_goals_.reserve(preserved_reached.size());
-        for (const auto& entry : preserved_reached)
-        {
-          reached_intermediate_goals_.push_back(entry.second);
-        }
-        unsigned int plan_last_index = plan.empty() ? 0u : static_cast<unsigned int>(plan.size() - 1);
-        last_progress_index_ = std::min(restored_progress_index, plan_last_index);
-      }
-      else
-      {
-        reached_intermediate_goals_.clear();
-        unsigned int plan_last_index = plan.empty() ? 0u : static_cast<unsigned int>(plan.size() - 1);
-        last_progress_index_ = std::min(previous_progress_index, plan_last_index);
-      }
-    }
-    else
-    {
-      reached_intermediate_goals_.clear();
-      last_progress_index_ = 0u;
-      holding_goal_ = false;
-      held_goal_index_ = 0u;
-      held_goal_pose_.x = 0.0;
-      held_goal_pose_.y = 0.0;
-      held_goal_pose_.theta = 0.0;
-      initial_alignment_done_ = false;
-    }
-
-    have_last_plan_ = true;
-  }
-
-  last_plan_size_ = plan.size();
-  last_plan_end_pose_ = plan.back();
-  last_plan_frame_id_ = global_plan.header.frame_id;
-  last_plan_stamp_ = global_plan.header.stamp;
-  last_plan_seq_ = global_plan.header.seq;
-  last_plan_start_pose_ = plan_start_pose;
-  last_final_goal_pose_ = final_goal;
-  have_last_goal_pose_ = true;
-
-
-  unsigned int plan_last_index = static_cast<unsigned int>(plan.size() - 1);
-
-  if (initial_alignment_done_ && plan.size() > 1 && last_progress_index_ > 0)
-  {
-    unsigned int prune_limit = std::min(last_progress_index_, plan_last_index);
-    if (prune_limit > 0)
-    {
-      plan.erase(plan.begin(), plan.begin() + prune_limit);
-      last_progress_index_ = last_progress_index_ >= prune_limit ? last_progress_index_ - prune_limit : 0;
-      plan_last_index = static_cast<unsigned int>(plan.size() - 1);
-
-      if (holding_goal_)
-      {
-        if (held_goal_index_ < prune_limit)
-        {
-          holding_goal_ = false;
-          held_goal_index_ = 0;
-        }
-        else
-        {
-          held_goal_index_ -= prune_limit;
-        }
-      }
-    }
-  }
-
-  if (holding_goal_ && held_goal_index_ >= plan.size())
-  {
-    ROS_DEBUG_NAMED("PathProgressCritic", "Held goal index %u is out of range for current plan of size %zu. Releasing hold.",
-                    held_goal_index_, plan.size());
-    holding_goal_ = false;
-    held_goal_index_ = 0;
-  }
 
   // find the "start pose", i.e. the pose on the plan closest to the robot that is also on the local map
   unsigned int start_index = 0;
@@ -504,834 +157,94 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     }
   }
 
-  auto collectArticulationIndices = [&](unsigned int scan_start, unsigned int scan_end) {
-    std::vector<unsigned int> articulation_indices;
-    if (plan.size() < 2)
-    {
-      return articulation_indices;
-    }
+  // find the "goal pose" by walking along the plan as long as each step leads far enough away from the starting point,
+  // i.e. is within angle_threshold_ of the starting direction.
+  unsigned int goal_index = start_index;
 
-    const double epsilon = 1e-9;
-    unsigned int clamped_start = std::max(scan_start, 1u);
-    unsigned int clamped_end = std::min(scan_end, plan_last_index);
-    if (clamped_start > clamped_end)
-    {
-      return articulation_indices;
-    }
+  while (goal_index < last_valid_index)
+  {
+    goal_index = getGoalIndex(plan, start_index, last_valid_index);
 
-    double previous_segment_angle = 0.0;
-    bool previous_segment_angle_set = false;
-    unsigned int previous_segment_end_index = 0u;
-
-    for (unsigned int i = clamped_start; i <= clamped_end; ++i)
+    // check if goal already reached
+    bool goal_already_reached = false;
+    for (auto& reached_intermediate_goal : reached_intermediate_goals_)
     {
-      double direction_x = plan[i].x - plan[i - 1].x;
-      double direction_y = plan[i].y - plan[i - 1].y;
-      double length = hypot(direction_x, direction_y);
-      if (length < epsilon)
+      double distance = nav_2d_utils::poseDistance(reached_intermediate_goal, plan[goal_index]);
+      if (distance < xy_local_goal_tolerance_)
       {
-        continue;
-      }
-
-      double current_angle = atan2(direction_y, direction_x);
-      if (previous_segment_angle_set)
-      {
-        double articulation_angle =
-            fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
-        if (articulation_angle >= articulation_angle_threshold_)
+        goal_already_reached = true;
+        // choose a new start_index by walking along the plan until we're outside xy_local_goal_tolerance_ and try again
+        // (start_index is now > goal_index)
+        for (start_index = goal_index; start_index <= last_valid_index; ++start_index)
         {
-          if (articulation_indices.empty() || articulation_indices.back() != previous_segment_end_index)
+          distance = nav_2d_utils::poseDistance(reached_intermediate_goal, plan[start_index]);
+          if (distance >= xy_local_goal_tolerance_)
           {
-            articulation_indices.push_back(previous_segment_end_index);
+            break;
           }
         }
-      }
-
-      previous_segment_angle = current_angle;
-      previous_segment_angle_set = true;
-      previous_segment_end_index = i;
-    }
-
-    return articulation_indices;
-  };
-
-  auto publishArticulationPointCloud = [&](const std::vector<unsigned int>& articulation_indices) {
-    if (!articulation_points_pub_)
-    {
-      return;
-    }
-
-    sensor_msgs::PointCloud cloud_msg;
-    cloud_msg.header = global_plan.header;
-    cloud_msg.header.stamp = ros::Time::now();
-    cloud_msg.points.reserve(articulation_indices.size());
-
-    for (unsigned int index : articulation_indices)
-    {
-      if (index >= plan.size())
-      {
-        continue;
-      }
-
-      geometry_msgs::Point32 point;
-      point.x = plan[index].x;
-      point.y = plan[index].y;
-      point.z = 0.0;
-      cloud_msg.points.push_back(point);
-    }
-
-    articulation_points_pub_.publish(cloud_msg);
-  };
-
-  auto publishIntermediateGoal = [&](const geometry_msgs::Pose2D& goal_pose, double goal_yaw) {
-    if (!intermediate_goal_pub_)
-    {
-      return;
-    }
-    geometry_msgs::PoseStamped goal_msg;
-    goal_msg.header = global_plan.header;
-    goal_msg.header.stamp = ros::Time::now();
-    goal_msg.pose.position.x = goal_pose.x;
-    goal_msg.pose.position.y = goal_pose.y;
-    goal_msg.pose.position.z = 0.0;
-    tf2::Quaternion q;
-    q.setRPY(0.0, 0.0, goal_yaw);
-    goal_msg.pose.orientation.x = q.x();
-    goal_msg.pose.orientation.y = q.y();
-    goal_msg.pose.orientation.z = q.z();
-    goal_msg.pose.orientation.w = q.w();
-    intermediate_goal_pub_.publish(goal_msg);
-
-    if (intermediate_goal_tolerance_pub_)
-    {
-      visualization_msgs::MarkerArray marker_array;
-      visualization_msgs::Marker marker;
-      marker.header = goal_msg.header;
-      marker.header.stamp = goal_msg.header.stamp;
-      marker.ns = "intermediate_goal_tolerance";
-      marker.id = 0;
-      marker.type = visualization_msgs::Marker::SPHERE;
-      marker.action = visualization_msgs::Marker::ADD;
-      marker.pose.position = goal_msg.pose.position;
-      marker.pose.orientation.x = 0.0;
-      marker.pose.orientation.y = 0.0;
-      marker.pose.orientation.z = 0.0;
-      marker.pose.orientation.w = 1.0;
-      double diameter = std::max(2.0 * xy_local_goal_tolerance_, 1e-6);
-      marker.scale.x = diameter;
-      marker.scale.y = diameter;
-      marker.scale.z = diameter;
-      marker.color.r = 0.2f;
-      marker.color.g = 0.8f;
-      marker.color.b = 0.4f;
-      marker.color.a = 0.35f;
-      marker.lifetime = ros::Duration(0.0);
-      marker_array.markers.push_back(marker);
-      intermediate_goal_tolerance_pub_.publish(marker_array);
-    }
-  };
-
-  if (!initial_alignment_done_)
-  {
-    double desired_initial_yaw = plan.front().theta;
-    if (!plan.empty())
-    {
-      double outgoing_angle = desired_initial_yaw;
-      if (computeOutgoingAngle(plan, 0u, outgoing_angle))
-      {
-        desired_initial_yaw = outgoing_angle;
-      }
-    }
-
-    double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, desired_initial_yaw));
-    if (yaw_error >= yaw_local_goal_tolerance_)
-    {
-      unsigned int rx = 0;
-      unsigned int ry = 0;
-      if (worldToGridBounded(info, robot_pose.x, robot_pose.y, rx, ry))
-      {
-        x = rx;
-        y = ry;
-        desired_angle = desired_initial_yaw;
-        held_goal_pose_.x = robot_pose.x;
-        held_goal_pose_.y = robot_pose.y;
-        held_goal_pose_.theta = desired_initial_yaw;
-        held_goal_index_ = 0;
-        holding_goal_ = true;
-        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
-        ROS_DEBUG_NAMED("PathProgressCritic",
-                        "Initial alignment: rotate in place to yaw %.3f rad at robot pose (x: %.3f, y: %.3f)",
-                        held_goal_pose_.theta, held_goal_pose_.x, held_goal_pose_.y);
-        return true;
-      }
-    }
-
-    initial_alignment_done_ = true;
-  }
-
-  std::vector<unsigned int> articulation_indices = collectArticulationIndices(1u, plan_last_index);
-  publishArticulationPointCloud(articulation_indices);
-
-  if (holding_goal_)
-  {
-    unsigned int held_x = 0;
-    unsigned int held_y = 0;
-    bool held_in_costmap = worldToGridBounded(info, held_goal_pose_.x, held_goal_pose_.y, held_x, held_y);
-
-    if (!held_in_costmap)
-    {
-      ROS_WARN_NAMED("PathProgressCritic",
-                     "Held goal (index %u) is outside the local costmap. Releasing hold to search for a new goal.",
-                     held_goal_index_);
-      holding_goal_ = false;
-      held_goal_index_ = 0;
-    }
-    else
-    {
-      double held_xy_tolerance =
-          (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ? final_goal_xy_tolerance_ :
-                                                                             xy_local_goal_tolerance_;
-      double held_yaw_tolerance =
-          (final_goal_in_plan_window && held_goal_index_ == plan_last_index) ? final_goal_yaw_tolerance_ :
-                                                                              yaw_local_goal_tolerance_;
-
-      double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, held_goal_pose_.theta));
-      if (yaw_error >= held_yaw_tolerance)
-      {
-        x = held_x;
-        y = held_y;
-        desired_angle = held_goal_pose_.theta;
-        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
-        ROS_DEBUG_NAMED("PathProgressCritic", "Holding goal index %u due to yaw error %.3f rad (threshold %.3f)",
-                        held_goal_index_, yaw_error, held_yaw_tolerance);
-        return true;
-      }
-
-      if (!isPoseReached(robot_pose, held_goal_pose_, held_goal_pose_.theta, held_xy_tolerance, held_yaw_tolerance))
-      {
-        x = held_x;
-        y = held_y;
-        desired_angle = held_goal_pose_.theta;
-        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
-        ROS_DEBUG_NAMED("PathProgressCritic",
-                        "Holding goal index %u until full pose tolerance satisfied (XY + yaw)", held_goal_index_);
-        return true;
-      }
-
-      last_progress_index_ = std::max(last_progress_index_, held_goal_index_);
-      geometry_msgs::Pose2D reached_pose = held_goal_pose_;
-      if (reached_intermediate_goals_.empty() ||
-          nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
-          fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) > 1e-6)
-      {
-        reached_intermediate_goals_.push_back(reached_pose);
-      }
-      ROS_DEBUG_NAMED("PathProgressCritic",
-                      "Reached held intermediate goal index %u while respecting pose tolerances. last_progress_index_: %u",
-                      held_goal_index_, last_progress_index_);
-      holding_goal_ = false;
-    }
-  }
-
-  // Constrain the search range to enforce monotonic progress with the updated bookkeeping.
-  last_progress_index_ = std::min(last_progress_index_, plan_last_index);
-
-  unsigned int search_start_index = std::max(start_index, last_progress_index_);
-  search_start_index = std::min(search_start_index, last_valid_index);
-
-  if (holding_goal_ && held_goal_index_ >= last_progress_index_)
-  {
-    search_start_index = std::min(search_start_index, held_goal_index_);
-  }
-
-  unsigned int articulation_scan_start = 0u;
-  if (plan_last_index >= 1)
-  {
-    unsigned int next_index = last_progress_index_ < plan_last_index ? last_progress_index_ + 1 : plan_last_index;
-    articulation_scan_start = std::max(next_index, 1u);
-  }
-  else
-  {
-    articulation_scan_start = plan_last_index;
-  }
-
-  auto articulationSearchStart = [&](unsigned int candidate_start) {
-    return std::max({candidate_start, articulation_scan_start, 1u});
-  };
-
-  unsigned int goal_index = search_start_index;
-  double goal_yaw = plan[goal_index].theta;
-  bool has_forward_direction = false;
-  bool found_goal = false;
-  bool forced_skipped_articulation = false;
-  unsigned int next_articulation_index = 0;
-  double next_articulation_yaw = 0.0;
-  bool next_articulation_has_forward = false;
-  bool has_next_articulation = false;
-
-  if (initial_alignment_done_ && !articulation_indices.empty())
-  {
-    unsigned int articulation_window_start = std::max(search_start_index, last_progress_index_ + 1);
-    unsigned int articulation_window_end = last_valid_index;
-
-    for (unsigned int idx : articulation_indices)
-    {
-      if (idx < articulation_window_start || idx > articulation_window_end)
-      {
-        continue;
-      }
-
-      double articulation_yaw = plan[idx].theta;
-      bool articulation_has_forward = computeOutgoingAngle(plan, idx, articulation_yaw);
-      double articulation_goal_yaw = articulation_has_forward ? articulation_yaw : plan[idx].theta;
-
-      double articulation_xy_tolerance =
-          (final_goal_in_plan_window && idx == plan_last_index) ? final_goal_xy_tolerance_ : xy_local_goal_tolerance_;
-      double articulation_yaw_tolerance =
-          (final_goal_in_plan_window && idx == plan_last_index) ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
-
-      if (isPoseReached(robot_pose, plan[idx], articulation_goal_yaw, articulation_xy_tolerance,
-                        articulation_yaw_tolerance))
-      {
-        last_progress_index_ = std::max(last_progress_index_, idx);
-        geometry_msgs::Pose2D reached_pose = plan[idx];
-        reached_pose.theta = articulation_goal_yaw;
-        if (reached_intermediate_goals_.empty() ||
-            nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
-            fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) >
-                1e-6)
-        {
-          reached_intermediate_goals_.push_back(reached_pose);
-        }
-        continue;
-      }
-
-      next_articulation_index = idx;
-      next_articulation_yaw = articulation_goal_yaw;
-      next_articulation_has_forward = articulation_has_forward;
-      has_next_articulation = true;
-      break;
-    }
-  }
-
-  if (!found_goal && initial_alignment_done_ && search_start_index > last_progress_index_ + 1 &&
-      !articulation_indices.empty())
-  {
-    unsigned int articulation_lower_bound = std::max(last_progress_index_ + 1, 1u);
-    unsigned int articulation_upper_bound = std::min(search_start_index - 1, last_valid_index);
-
-    if (articulation_lower_bound <= articulation_upper_bound)
-    {
-      auto articulation_it = std::find_if(articulation_indices.begin(), articulation_indices.end(),
-                                          [&](unsigned int index) {
-                                            return index >= articulation_lower_bound && index <= articulation_upper_bound;
-                                          });
-
-      if (articulation_it != articulation_indices.end())
-      {
-        goal_index = *articulation_it;
-        has_forward_direction = computeOutgoingAngle(plan, goal_index, goal_yaw);
-        if (!has_forward_direction)
-        {
-          goal_yaw = plan[goal_index].theta;
-        }
-
-        if (enforce_forward_dot_ && has_forward_direction)
-        {
-          double to_goal_x = plan[goal_index].x - robot_pose.x;
-          double to_goal_y = plan[goal_index].y - robot_pose.y;
-          double dot = to_goal_x * std::cos(goal_yaw) + to_goal_y * std::sin(goal_yaw);
-          if (dot < 0.0)
-          {
-            ROS_WARN_NAMED("PathProgressCritic",
-                           "Forcing skipped articulation index %u despite backward dot product %.3f due to policy.",
-                           goal_index, dot);
-          }
-        }
-
-        forced_skipped_articulation = true;
-        found_goal = true;
-        ROS_DEBUG_NAMED("PathProgressCritic",
-                        "Recovered skipped articulation index %u between progress %u and search start %u.",
-                        goal_index, last_progress_index_, search_start_index);
-      }
-    }
-  }
-
-  unsigned int search_index = search_start_index;
-  while (!forced_skipped_articulation && search_index <= last_valid_index)
-  {
-    double candidate_yaw = goal_yaw;
-    bool candidate_has_forward = false;
-    unsigned int candidate_index =
-        getGoalIndex(plan, search_index, last_valid_index, final_goal_in_plan_window, candidate_yaw, candidate_has_forward);
-
-    bool forced_articulation = false;
-    if (candidate_index > last_progress_index_)
-    {
-      unsigned int articulation_index = 0;
-      double articulation_yaw = candidate_yaw;
-      bool articulation_has_forward = candidate_has_forward;
-      unsigned int articulation_start_index = articulationSearchStart(search_index);
-      if (articulation_start_index <= candidate_index &&
-          findNextArticulation(plan, articulation_start_index, candidate_index, last_valid_index,
-                               articulation_index, articulation_yaw, articulation_has_forward))
-      {
-        candidate_index = articulation_index;
-        candidate_yaw = articulation_yaw;
-        candidate_has_forward = articulation_has_forward;
-        forced_articulation = true;
-      }
-    }
-
-    if (!forced_articulation)
-    {
-      candidate_index = std::max(candidate_index, search_index);
-    }
-
-    if (has_next_articulation && candidate_index >= next_articulation_index)
-    {
-      goal_index = next_articulation_index;
-      goal_yaw = next_articulation_yaw;
-      has_forward_direction = next_articulation_has_forward;
-      found_goal = true;
-      forced_skipped_articulation = true;
-      has_next_articulation = false;
-      ROS_DEBUG_NAMED("PathProgressCritic",
-                      "Selecting pending articulation index %u reached at candidate %u.", goal_index,
-                      candidate_index);
-      break;
-    }
-
-    double candidate_xy_tolerance =
-        (final_goal_in_plan_window && candidate_index == plan_last_index) ? final_goal_xy_tolerance_ :
-                                                                           xy_local_goal_tolerance_;
-    double candidate_yaw_tolerance =
-        (final_goal_in_plan_window && candidate_index == plan_last_index) ? final_goal_yaw_tolerance_ :
-                                                                            yaw_local_goal_tolerance_;
-
-    if (isPoseReached(robot_pose, plan[candidate_index], candidate_yaw, candidate_xy_tolerance,
-                      candidate_yaw_tolerance))
-    {
-      last_progress_index_ = std::max(last_progress_index_, candidate_index);
-      geometry_msgs::Pose2D reached_pose = plan[candidate_index];
-      reached_pose.theta = candidate_yaw;
-      if (reached_intermediate_goals_.empty() ||
-          nav_2d_utils::poseDistance(reached_intermediate_goals_.back(), reached_pose) > 1e-6 ||
-          fabs(angles::shortest_angular_distance(reached_intermediate_goals_.back().theta, reached_pose.theta)) > 1e-6)
-      {
-        reached_intermediate_goals_.push_back(reached_pose);
-      }
-      ROS_DEBUG_NAMED("PathProgressCritic",
-                      "Reached intermediate goal index %u. last_progress_index_: %u", candidate_index,
-                      last_progress_index_);
-
-      if (candidate_index >= last_valid_index)
-      {
-        goal_index = candidate_index;
-        goal_yaw = candidate_yaw;
-        has_forward_direction = candidate_has_forward;
-        found_goal = true;
-        break;
-      }
-
-      search_index = candidate_index + 1;
-      continue;
-    }
-
-    if (enforce_forward_dot_ && candidate_has_forward && !forced_articulation)
-    {
-      double to_goal_x = plan[candidate_index].x - robot_pose.x;
-      double to_goal_y = plan[candidate_index].y - robot_pose.y;
-      double dot = to_goal_x * std::cos(candidate_yaw) + to_goal_y * std::sin(candidate_yaw);
-      if (dot < 0.0)
-      {
-        ROS_DEBUG_NAMED("PathProgressCritic",
-                        "Skipping goal index %u due to backward alignment (dot product %.3f)", candidate_index, dot);
-        if (candidate_index >= last_valid_index)
-        {
-          break;
-        }
-        search_index = candidate_index + 1;
-        continue;
-      }
-    }
-
-    goal_index = candidate_index;
-    goal_yaw = candidate_yaw;
-    has_forward_direction = candidate_has_forward;
-    found_goal = true;
-    break;
-  }
-
-  if (!found_goal)
-  {
-    unsigned int fallback_start = std::min(last_valid_index, search_start_index);
-    goal_index = fallback_start;
-    bool selected_fallback = false;
-
-    for (; goal_index <= last_valid_index; ++goal_index)
-    {
-      has_forward_direction = computeOutgoingAngle(plan, goal_index, goal_yaw);
-      if (has_forward_direction)
-      {
-        if (!enforce_forward_dot_)
-        {
-          selected_fallback = true;
-          break;
-        }
-
-        double to_goal_x = plan[goal_index].x - robot_pose.x;
-        double to_goal_y = plan[goal_index].y - robot_pose.y;
-        double dot = to_goal_x * std::cos(goal_yaw) + to_goal_y * std::sin(goal_yaw);
-        if (dot >= 0.0)
-        {
-          selected_fallback = true;
-          break;
-        }
-        continue;
-      }
-
-      goal_yaw = plan[goal_index].theta;
-      if (!enforce_forward_dot_ || goal_index == last_valid_index)
-      {
-        selected_fallback = true;
         break;
       }
     }
-
-    if (!selected_fallback)
+    if (!goal_already_reached)
     {
-      return false;
-    }
-
-    if (has_next_articulation && goal_index >= next_articulation_index)
-    {
-      goal_index = next_articulation_index;
-      goal_yaw = next_articulation_yaw;
-      has_forward_direction = next_articulation_has_forward;
-      has_next_articulation = false;
-      forced_skipped_articulation = true;
-      ROS_DEBUG_NAMED("PathProgressCritic",
-                      "Fallback switching to pending articulation index %u.", goal_index);
-    }
-
-    if (goal_index > last_progress_index_)
-    {
-      unsigned int articulation_index = 0;
-      double articulation_yaw = goal_yaw;
-      bool articulation_has_forward = has_forward_direction;
-      unsigned int articulation_start_index = articulationSearchStart(search_start_index);
-      if (articulation_start_index <= goal_index &&
-          findNextArticulation(plan, articulation_start_index, goal_index, last_valid_index,
-                               articulation_index, articulation_yaw, articulation_has_forward))
+      // new goal not in reached_intermediate_goals_
+      double distance = nav_2d_utils::poseDistance(plan[goal_index], robot_pose);
+      if (distance < xy_local_goal_tolerance_)
       {
-        goal_index = articulation_index;
-        goal_yaw = articulation_yaw;
-        has_forward_direction = articulation_has_forward;
+        // the robot has currently reached the goal
+        reached_intermediate_goals_.push_back(plan[goal_index]);
+        ROS_DEBUG_NAMED("PathProgressCritic", "Number of reached_intermediate goals: %zu",
+                        reached_intermediate_goals_.size());
+      }
+      else
+      {
+        // we've found a new goal!
+        break;
       }
     }
   }
-
-  if (final_goal_in_plan_window && plan_last_index <= last_valid_index && goal_index != plan_last_index)
-  {
-    double snap_threshold = final_goal_xy_tolerance_;
-    if (snap_threshold >= 0.0)
-    {
-      double final_dx = plan[plan_last_index].x - plan[goal_index].x;
-      double final_dy = plan[plan_last_index].y - plan[goal_index].y;
-      double distance_to_final = hypot(final_dx, final_dy);
-      if (distance_to_final <= snap_threshold)
-      {
-        ROS_DEBUG_NAMED("PathProgressCritic",
-                        "Snapping intermediate goal index %u to final goal because distance %.3f <= threshold %.3f",
-                        goal_index, distance_to_final, snap_threshold);
-        goal_index = plan_last_index;
-        goal_yaw = plan[plan_last_index].theta;
-        has_forward_direction = false;
-        forced_skipped_articulation = false;
-        has_next_articulation = false;
-      }
-    }
-  }
-
-  bool pending_articulation = false;
-  if (last_progress_index_ < goal_index)
-  {
-    pending_articulation = std::find(articulation_indices.begin(), articulation_indices.end(), goal_index) !=
-                           articulation_indices.end();
-  }
-
-  // Only consider snapping to the final goal yaw when we have already selected the last path index as goal.
-  // Otherwise, keep following the path even if the final goal is within tolerance.
-  if (!pending_articulation && final_goal_xy_tolerance_ >= 0.0 && final_goal_in_plan_window &&
-      plan_last_index <= last_valid_index && goal_index == plan_last_index)
-  {
-    double final_dx = plan[plan_last_index].x - plan[goal_index].x;
-    double final_dy = plan[plan_last_index].y - plan[goal_index].y;
-    double final_distance = hypot(final_dx, final_dy);
-    if (final_distance <= final_goal_xy_tolerance_)
-    {
-      goal_index = plan_last_index;
-      goal_yaw = plan[plan_last_index].theta;
-      has_forward_direction = false;
-    }
-  }
-
+  if (start_index > goal_index)
+    start_index = goal_index;
   ROS_ASSERT(goal_index <= last_valid_index);
 
+  // save goal in x, y
   worldToGridBounded(info, plan[goal_index].x, plan[goal_index].y, x, y);
-  desired_angle = goal_yaw;
-
-  bool same_as_held = false;
-  if (holding_goal_)
-  {
-    double position_diff_x = plan[goal_index].x - held_goal_pose_.x;
-    double position_diff_y = plan[goal_index].y - held_goal_pose_.y;
-    double yaw_diff = angles::shortest_angular_distance(goal_yaw, held_goal_pose_.theta);
-    same_as_held = (fabs(position_diff_x) <= hold_position_epsilon_) &&
-                   (fabs(position_diff_y) <= hold_position_epsilon_) &&
-                   (fabs(yaw_diff) <= hold_yaw_epsilon_);
-  }
-
-  if (!same_as_held)
-  {
-    held_goal_pose_ = plan[goal_index];
-    held_goal_pose_.theta = goal_yaw;
-    held_goal_index_ = goal_index;
-  }
-  else
-  {
-    held_goal_pose_.x = plan[goal_index].x;
-    held_goal_pose_.y = plan[goal_index].y;
-    held_goal_pose_.theta = goal_yaw;
-  }
-  holding_goal_ = true;
-
-  ROS_DEBUG_NAMED("PathProgressCritic",
-                  "Selected goal index %u (x: %.3f, y: %.3f, yaw: %.3f rad). last_progress_index_: %u",
-                  goal_index, plan[goal_index].x, plan[goal_index].y, goal_yaw, last_progress_index_);
-
-  publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
+  desired_angle = plan[start_index].theta;
   return true;
 }
 
 unsigned int PathProgressCritic::getGoalIndex(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
-                                              unsigned int last_valid_index, bool plan_tail_is_final_goal,
-                                              double& desired_angle, bool& has_forward_direction) const
+                                              unsigned int last_valid_index) const
 {
-  if (plan.empty())
+  if (start_index >= last_valid_index)
+    return last_valid_index;
+
+  unsigned int goal_index = start_index;
+  const double start_direction_x = plan[start_index + 1].x - plan[start_index].x;
+  const double start_direction_y = plan[start_index + 1].y - plan[start_index].y;
+  if (fabs(start_direction_x) > 1e-9 || fabs(start_direction_y) > 1e-9)
   {
-    desired_angle = 0.0;
-    has_forward_direction = false;
-    return 0;
-  }
+    // make sure that atan2 is defined
+    double start_angle = atan2(start_direction_y, start_direction_x);
 
-  const double epsilon = 1e-9;
-  unsigned int clamped_start = std::min(start_index, static_cast<unsigned int>(plan.size() - 1));
-  unsigned int clamped_last = std::min(last_valid_index, static_cast<unsigned int>(plan.size() - 1));
-
-  if (clamped_start >= clamped_last)
-  {
-    has_forward_direction = computeOutgoingAngle(plan, clamped_start, desired_angle);
-    if (!has_forward_direction)
+    for (unsigned int i = start_index + 1; i <= last_valid_index; ++i)
     {
-      desired_angle = plan[clamped_start].theta;
-    }
-    return clamped_start;
-  }
-
-  unsigned int goal_index = clamped_start;
-  double base_angle = 0.0;
-  bool base_angle_set = false;
-  double previous_segment_angle = 0.0;
-  bool previous_segment_angle_set = false;
-  unsigned int previous_segment_end_index = clamped_start;
-  double last_valid_segment_angle = 0.0;
-  bool last_valid_segment_angle_set = false;
-
-  for (unsigned int i = clamped_start + 1; i <= clamped_last; ++i)
-  {
-    double direction_x = plan[i].x - plan[i - 1].x;
-    double direction_y = plan[i].y - plan[i - 1].y;
-    double length = hypot(direction_x, direction_y);
-    if (length < epsilon)
-    {
-      continue;
-    }
-
-    double current_angle = atan2(direction_y, direction_x);
-    last_valid_segment_angle = current_angle;
-    last_valid_segment_angle_set = true;
-
-    if (!base_angle_set)
-    {
-      base_angle = current_angle;
-      base_angle_set = true;
-    }
-
-    if (previous_segment_angle_set)
-    {
-      double articulation_angle = fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
-      if (articulation_angle >= articulation_angle_threshold_)
+      const double current_direction_x = plan[i].x - plan[i - 1].x;
+      const double current_direction_y = plan[i].y - plan[i - 1].y;
+      if (fabs(current_direction_x) > 1e-9 || fabs(current_direction_y) > 1e-9)
       {
-        goal_index = previous_segment_end_index;
-        break;
+        double current_angle = atan2(current_direction_y, current_direction_x);
+
+        // goal pose is found if plan doesn't point far enough away from the starting point
+        if (fabs(remainder(start_angle - current_angle, 2 * M_PI)) > angle_threshold_)
+          break;
+
+        goal_index = i;
       }
     }
-
-    double deviation = fabs(angles::shortest_angular_distance(base_angle, current_angle));
-    if (deviation > angle_threshold_)
-    {
-      break;
-    }
-
-    goal_index = i;
-    previous_segment_angle = current_angle;
-    previous_segment_end_index = i;
-    previous_segment_angle_set = true;
   }
-
-  has_forward_direction = computeOutgoingAngle(plan, goal_index, desired_angle);
-  if (!has_forward_direction)
-  {
-    if (plan_tail_is_final_goal && goal_index == plan.size() - 1)
-    {
-      desired_angle = plan[goal_index].theta;
-    }
-    else if (previous_segment_angle_set)
-    {
-      desired_angle = previous_segment_angle;
-      has_forward_direction = true;
-    }
-    else if (last_valid_segment_angle_set)
-    {
-      desired_angle = last_valid_segment_angle;
-      has_forward_direction = true;
-    }
-    else
-    {
-      desired_angle = plan[goal_index].theta;
-    }
-  }
-
-  if (plan_tail_is_final_goal && goal_index == plan.size() - 1)
-  {
-    has_forward_direction = false;
-  }
-
   return goal_index;
-}
-
-bool PathProgressCritic::findNextArticulation(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int start_index,
-                                              unsigned int end_index, unsigned int last_valid_index,
-                                              unsigned int& articulation_index, double& articulation_yaw,
-                                              bool& has_forward_direction) const
-{
-  const double epsilon = 1e-9;
-  articulation_index = 0;
-  articulation_yaw = 0.0;
-  has_forward_direction = false;
-
-  if (plan.size() < 2)
-  {
-    return false;
-  }
-
-  unsigned int clamped_end = std::min(end_index, static_cast<unsigned int>(plan.size() - 1));
-  clamped_end = std::min(clamped_end, last_valid_index);
-  if (clamped_end < 1)
-  {
-    return false;
-  }
-
-  unsigned int scan_start = std::max(start_index, 1u);
-  if (scan_start > clamped_end)
-  {
-    return false;
-  }
-
-  double previous_segment_angle = 0.0;
-  bool previous_segment_angle_set = false;
-  unsigned int previous_segment_end_index = 0;
-
-  for (unsigned int i = scan_start; i <= clamped_end; ++i)
-  {
-    double direction_x = plan[i].x - plan[i - 1].x;
-    double direction_y = plan[i].y - plan[i - 1].y;
-    double length = hypot(direction_x, direction_y);
-    if (length < epsilon)
-    {
-      continue;
-    }
-
-    double current_angle = atan2(direction_y, direction_x);
-
-    if (previous_segment_angle_set)
-    {
-      double articulation_angle = fabs(angles::shortest_angular_distance(previous_segment_angle, current_angle));
-      if (articulation_angle >= articulation_angle_threshold_)
-      {
-        articulation_index = previous_segment_end_index;
-        articulation_yaw = current_angle;
-        has_forward_direction = true;
-        if (!computeOutgoingAngle(plan, articulation_index, articulation_yaw))
-        {
-          has_forward_direction = false;
-          if (articulation_index == plan.size() - 1)
-          {
-            articulation_yaw = plan[articulation_index].theta;
-          }
-        }
-        return true;
-      }
-    }
-
-    previous_segment_angle = current_angle;
-    previous_segment_angle_set = true;
-    previous_segment_end_index = i;
-  }
-
-  return false;
-}
-
-bool PathProgressCritic::computeOutgoingAngle(const std::vector<geometry_msgs::Pose2D>& plan, unsigned int index,
-                                              double& angle) const
-{
-  const double epsilon = 1e-9;
-  if (plan.empty() || index >= plan.size())
-  {
-    return false;
-  }
-
-  for (unsigned int i = index + 1; i < plan.size(); ++i)
-  {
-    double dx = plan[i].x - plan[index].x;
-    double dy = plan[i].y - plan[index].y;
-    double length = hypot(dx, dy);
-    if (length >= epsilon)
-    {
-      angle = atan2(dy, dx);
-      return true;
-    }
-  }
-
-  return false;
-}
-
-bool PathProgressCritic::isPoseReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
-                                       double goal_yaw, double xy_tolerance, double yaw_tolerance) const
-{
-  double distance = nav_2d_utils::poseDistance(goal_pose, robot_pose);
-  double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, goal_yaw));
-
-  return distance < xy_tolerance && yaw_error < yaw_tolerance;
-}
-
-bool PathProgressCritic::isGoalReached(const geometry_msgs::Pose2D& robot_pose, const geometry_msgs::Pose2D& goal_pose,
-                                       double goal_yaw) const
-{
-  return isPoseReached(robot_pose, goal_pose, goal_yaw, xy_local_goal_tolerance_, yaw_local_goal_tolerance_);
 }
 
 }  // namespace mir_dwb_critics

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -277,8 +277,29 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
     if (matchPoseToPlanIndex(robot_pose, robot_match_index))
     {
       state_preserved = true;
-      progress_match_found = true;
-      restored_progress_index = std::max(restored_progress_index, robot_match_index);
+
+      double match_goal_yaw = plan[robot_match_index].theta;
+      if (!computeOutgoingAngle(plan, robot_match_index, match_goal_yaw))
+      {
+        match_goal_yaw = plan[robot_match_index].theta;
+      }
+
+      bool match_is_final_index = (robot_match_index + 1u) >= plan.size();
+      double match_yaw_tolerance = match_is_final_index ? final_goal_yaw_tolerance_ : yaw_local_goal_tolerance_;
+      double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, match_goal_yaw));
+
+      if (yaw_error <= match_yaw_tolerance)
+      {
+        progress_match_found = true;
+        restored_progress_index = std::max(restored_progress_index, robot_match_index);
+      }
+      else
+      {
+        ROS_DEBUG_NAMED("PathProgressCritic",
+                        "Robot pose matched plan index %u but yaw error %.3f rad exceeds tolerance %.3f."
+                        " Preserving state without increasing progress.",
+                        robot_match_index, yaw_error, match_yaw_tolerance);
+      }
     }
 
     if (state_preserved)

--- a/mir_dwb_critics/src/path_progress.cpp
+++ b/mir_dwb_critics/src/path_progress.cpp
@@ -37,6 +37,7 @@
 #include <nav_grid/coordinate_conversion.h>
 #include <pluginlib/class_list_macros.h>
 #include <nav_2d_utils/path_ops.h>
+#include <ros/node_handle.h>
 #include <ros/time.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <algorithm>
@@ -71,6 +72,11 @@ void PathProgressCritic::onInit()
   dwb_critics::MapGridCritic::onInit();
   critic_nh_.param("xy_local_goal_tolerance", xy_local_goal_tolerance_, 0.20);
   critic_nh_.param("yaw_local_goal_tolerance", yaw_local_goal_tolerance_, 0.15);
+  ros::NodeHandle private_nh("~");
+  if (!private_nh.getParam("yaw_goal_tolerance", final_goal_yaw_tolerance_))
+  {
+    critic_nh_.param("yaw_goal_tolerance", final_goal_yaw_tolerance_, yaw_local_goal_tolerance_);
+  }
   critic_nh_.param("angle_threshold", angle_threshold_, M_PI_4);
   critic_nh_.param("articulation_angle_threshold", articulation_angle_threshold_, 1.3089969389957472);
   critic_nh_.param("heading_scale", heading_scale_, 1.0);
@@ -84,12 +90,25 @@ void PathProgressCritic::onInit()
   heading_scale_ /= getScale();
   last_progress_index_ = 0;
   reached_intermediate_goals_.clear();
+  holding_goal_ = false;
+  held_goal_index_ = 0;
+  held_goal_pose_.x = 0.0;
+  held_goal_pose_.y = 0.0;
+  held_goal_pose_.theta = 0.0;
+  hold_position_epsilon_ = 1e-6;
+  hold_yaw_epsilon_ = 1e-6;
+  final_goal_yaw_tolerance_ = std::max(final_goal_yaw_tolerance_, 1e-6);
 }
 
 void PathProgressCritic::reset()
 {
   reached_intermediate_goals_.clear();
   last_progress_index_ = 0;
+  holding_goal_ = false;
+  held_goal_index_ = 0;
+  held_goal_pose_.x = 0.0;
+  held_goal_pose_.y = 0.0;
+  held_goal_pose_.theta = 0.0;
 }
 
 double PathProgressCritic::scoreTrajectory(const dwb_msgs::Trajectory2D& traj)
@@ -119,6 +138,14 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   {
     ROS_ERROR_NAMED("PathProgressCritic", "The adjusted global plan was empty.");
     return false;
+  }
+
+  if (holding_goal_ && held_goal_index_ >= plan.size())
+  {
+    ROS_DEBUG_NAMED("PathProgressCritic", "Held goal index %u is out of range for current plan of size %zu. Releasing hold.",
+                    held_goal_index_, plan.size());
+    holding_goal_ = false;
+    held_goal_index_ = 0;
   }
 
   // find the "start pose", i.e. the pose on the plan closest to the robot that is also on the local map
@@ -185,6 +212,52 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
 
   unsigned int search_start_index = std::max(start_index, last_progress_index_);
   search_start_index = std::min(search_start_index, last_valid_index);
+
+  auto publishIntermediateGoal = [&](const geometry_msgs::Pose2D& goal_pose, double goal_yaw) {
+    if (!intermediate_goal_pub_)
+    {
+      return;
+    }
+    geometry_msgs::PoseStamped goal_msg;
+    goal_msg.header = global_plan.header;
+    goal_msg.header.stamp = ros::Time::now();
+    goal_msg.pose.position.x = goal_pose.x;
+    goal_msg.pose.position.y = goal_pose.y;
+    goal_msg.pose.position.z = 0.0;
+    tf2::Quaternion q;
+    q.setRPY(0.0, 0.0, goal_yaw);
+    goal_msg.pose.orientation.x = q.x();
+    goal_msg.pose.orientation.y = q.y();
+    goal_msg.pose.orientation.z = q.z();
+    goal_msg.pose.orientation.w = q.w();
+    intermediate_goal_pub_.publish(goal_msg);
+  };
+
+  if (holding_goal_)
+  {
+    double yaw_error = fabs(angles::shortest_angular_distance(robot_pose.theta, held_goal_pose_.theta));
+    if (yaw_error >= final_goal_yaw_tolerance_)
+    {
+      unsigned int held_x = 0;
+      unsigned int held_y = 0;
+      if (worldToGridBounded(info, held_goal_pose_.x, held_goal_pose_.y, held_x, held_y))
+      {
+        x = held_x;
+        y = held_y;
+        desired_angle = held_goal_pose_.theta;
+        publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
+        ROS_DEBUG_NAMED("PathProgressCritic", "Holding goal index %u due to yaw error %.3f rad (threshold %.3f)",
+                        held_goal_index_, yaw_error, final_goal_yaw_tolerance_);
+        return true;
+      }
+
+      ROS_WARN_NAMED("PathProgressCritic",
+                     "Held goal (index %u) is outside the local costmap. Releasing hold to search for a new goal.",
+                     held_goal_index_);
+      holding_goal_ = false;
+      held_goal_index_ = 0;
+    }
+  }
 
   unsigned int goal_index = search_start_index;
   double goal_yaw = plan[goal_index].theta;
@@ -301,26 +374,36 @@ bool PathProgressCritic::getGoalPose(const geometry_msgs::Pose2D& robot_pose, co
   worldToGridBounded(info, plan[goal_index].x, plan[goal_index].y, x, y);
   desired_angle = goal_yaw;
 
+  bool same_as_held = false;
+  if (holding_goal_)
+  {
+    double position_diff_x = plan[goal_index].x - held_goal_pose_.x;
+    double position_diff_y = plan[goal_index].y - held_goal_pose_.y;
+    double yaw_diff = angles::shortest_angular_distance(goal_yaw, held_goal_pose_.theta);
+    same_as_held = (fabs(position_diff_x) <= hold_position_epsilon_) &&
+                   (fabs(position_diff_y) <= hold_position_epsilon_) &&
+                   (fabs(yaw_diff) <= hold_yaw_epsilon_);
+  }
+
+  if (!same_as_held)
+  {
+    held_goal_pose_ = plan[goal_index];
+    held_goal_pose_.theta = goal_yaw;
+    held_goal_index_ = goal_index;
+  }
+  else
+  {
+    held_goal_pose_.x = plan[goal_index].x;
+    held_goal_pose_.y = plan[goal_index].y;
+    held_goal_pose_.theta = goal_yaw;
+  }
+  holding_goal_ = true;
+
   ROS_DEBUG_NAMED("PathProgressCritic",
                   "Selected goal index %u (x: %.3f, y: %.3f, yaw: %.3f rad). last_progress_index_: %u",
                   goal_index, plan[goal_index].x, plan[goal_index].y, goal_yaw, last_progress_index_);
 
-  if (intermediate_goal_pub_)
-  {
-    geometry_msgs::PoseStamped goal_pose;
-    goal_pose.header = global_plan.header;
-    goal_pose.header.stamp = ros::Time::now();
-    goal_pose.pose.position.x = plan[goal_index].x;
-    goal_pose.pose.position.y = plan[goal_index].y;
-    goal_pose.pose.position.z = 0.0;
-    tf2::Quaternion q;
-    q.setRPY(0.0, 0.0, goal_yaw);
-    goal_pose.pose.orientation.x = q.x();
-    goal_pose.pose.orientation.y = q.y();
-    goal_pose.pose.orientation.z = q.z();
-    goal_pose.pose.orientation.w = q.w();
-    intermediate_goal_pub_.publish(goal_pose);
-  }
+  publishIntermediateGoal(held_goal_pose_, held_goal_pose_.theta);
   return true;
 }
 

--- a/mir_navigation/CMakeLists.txt
+++ b/mir_navigation/CMakeLists.txt
@@ -22,6 +22,7 @@ catkin_package()
 install(PROGRAMS
   mprim/genmprim_unicycle_highcost_5cm.py
   nodes/acc_finder.py
+  nodes/global_plan_debug_viz.py
   nodes/min_max_finder.py
   scripts/plot_mprim.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/mir_navigation/config/dwb_local_planner_params.yaml
+++ b/mir_navigation/config/dwb_local_planner_params.yaml
@@ -49,7 +49,7 @@ DWBLocalPlanner:
 
   # Critics (trajectory scoring)
   #default_critic_namespaces: [dwb_critics, mir_dwb_critics]
-  critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathFollower]
+  critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathFollowerCritic]
   RotateToGoal:
     scale: 100.0
     # lookahead_time: -1.0
@@ -65,10 +65,10 @@ DWBLocalPlanner:
   PathDistPruned:
     scale: 32.0            # default: 32.0  mir: 32.0   - weighting for how much it should stick to the global path plan
     class: 'mir_dwb_critics::PathDistPruned'
-  PathFollower:
+  PathFollowerCritic:
     scale: 24.0            # default: 24.0  mir: 48.0   - weighting for how much it should attempt to reach its goal
     heading_scale: 0.1
-    class: 'mir_dwb_critics::PathFollower'
+    class: 'mir_dwb_critics::PathFollowerCritic'
     xy_local_goal_tolerance: 0.20
     yaw_local_goal_tolerance: 0.15
     angle_threshold: 0.78539816  # 45 degrees

--- a/mir_navigation/config/dwb_local_planner_params.yaml
+++ b/mir_navigation/config/dwb_local_planner_params.yaml
@@ -49,7 +49,7 @@ DWBLocalPlanner:
 
   # Critics (trajectory scoring)
   #default_critic_namespaces: [dwb_critics, mir_dwb_critics]
-  critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathProgress]
+  critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathFollower]
   RotateToGoal:
     scale: 100.0
     # lookahead_time: -1.0
@@ -65,12 +65,20 @@ DWBLocalPlanner:
   PathDistPruned:
     scale: 32.0            # default: 32.0  mir: 32.0   - weighting for how much it should stick to the global path plan
     class: 'mir_dwb_critics::PathDistPruned'
-  PathProgress:
+  PathFollower:
     scale: 24.0            # default: 24.0  mir: 48.0   - weighting for how much it should attempt to reach its goal
     heading_scale: 0.1
-    class: 'mir_dwb_critics::PathProgress'
+    class: 'mir_dwb_critics::PathFollower'
     xy_local_goal_tolerance: 0.20
+    yaw_local_goal_tolerance: 0.15
     angle_threshold: 0.78539816  # 45 degrees
+    articulation_angle_threshold: 1.3089969389957472  # 75 degrees
+    enforce_forward_dot: true
+    always_target_articulations: true
+    plan_alignment_position_tolerance: 0.15
+    plan_alignment_yaw_tolerance: 3.14159265358979323846
+    xy_goal_tolerance: 0.20
+    yaw_goal_tolerance: 0.15
 
 
   # Prune already passed poses from plan

--- a/mir_navigation/config/dwb_local_planner_params.yaml
+++ b/mir_navigation/config/dwb_local_planner_params.yaml
@@ -49,8 +49,8 @@ DWBLocalPlanner:
 
   # Critics (trajectory scoring)
   #default_critic_namespaces: [dwb_critics, mir_dwb_critics]
-  # critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathFollowerCritic]
-  critics: [RotateToGoal, PathFollowerCritic]
+  # critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathProgress]
+  critics: [RotateToGoal, PathFollower]
   RotateToGoal:
     scale: 10.0
     # lookahead_time: -1.0
@@ -66,11 +66,17 @@ DWBLocalPlanner:
   PathDistPruned:
     scale: 32.0            # default: 32.0  mir: 32.0   - weighting for how much it should stick to the global path plan
     class: 'mir_dwb_critics::PathDistPruned'
-  PathFollowerCritic:
+  PathProgress:
+    scale: 24.0            # default: 24.0  mir: 48.0   - weighting for how much it should attempt to reach its goal
+    heading_scale: 0.1
+    class: 'mir_dwb_critics::PathProgress'
+    xy_local_goal_tolerance: 0.20
+    angle_threshold: 0.78539816  # 45 degrees
+  PathFollower:
     scale: 24.0            # default: 24.0  mir: 48.0   - weighting for how much it should attempt to reach its goal
     heading_scale: 0.1
     xy_local_goal_tolerance: 0.1
-    class: 'mir_dwb_critics::PathFollowerCritic'
+    class: 'mir_dwb_critics::PathFollower'
     yaw_local_goal_tolerance: 0.15
     angle_threshold: 0.3   # 90 degrees, default: 0.78539816  -> 45 degrees
     articulation_angle_threshold: 1.3089969389957472  # 75 degrees

--- a/mir_navigation/config/dwb_local_planner_params.yaml
+++ b/mir_navigation/config/dwb_local_planner_params.yaml
@@ -68,7 +68,7 @@ DWBLocalPlanner:
   PathFollower:
     scale: 24.0            # default: 24.0  mir: 48.0   - weighting for how much it should attempt to reach its goal
     heading_scale: 0.1
-    class: 'mir_dwb_critics::PathFollowerCritic'
+    class: 'mir_dwb_critics::PathFollower'
     xy_local_goal_tolerance: 0.20
     yaw_local_goal_tolerance: 0.15
     angle_threshold: 0.78539816  # 45 degrees

--- a/mir_navigation/config/dwb_local_planner_params.yaml
+++ b/mir_navigation/config/dwb_local_planner_params.yaml
@@ -4,7 +4,7 @@ LocalPlannerAdapter:
 DWBLocalPlanner:
   # Robot configuration
   max_vel_x:  0.8
-  min_vel_x: -0.2
+  min_vel_x: -0.8 # NOTE: no preference over going forward
 
   max_vel_y: 0.0  # diff drive robot
   min_vel_y: 0.0  # diff drive robot
@@ -49,9 +49,10 @@ DWBLocalPlanner:
 
   # Critics (trajectory scoring)
   #default_critic_namespaces: [dwb_critics, mir_dwb_critics]
-  critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathFollowerCritic]
+  # critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathFollowerCritic]
+  critics: [PathFollowerCritic]
   RotateToGoal:
-    scale: 100.0
+    scale: 10.0
     # lookahead_time: -1.0
     # slowing_factor: 5.0
   ObstacleFootprint:
@@ -68,10 +69,10 @@ DWBLocalPlanner:
   PathFollowerCritic:
     scale: 24.0            # default: 24.0  mir: 48.0   - weighting for how much it should attempt to reach its goal
     heading_scale: 0.1
+    xy_local_goal_tolerance: 0.1
     class: 'mir_dwb_critics::PathFollowerCritic'
-    xy_local_goal_tolerance: 0.20
     yaw_local_goal_tolerance: 0.15
-    angle_threshold: 0.78539816  # 45 degrees
+    angle_threshold: 0.3   # 90 degrees, default: 0.78539816  -> 45 degrees
     articulation_angle_threshold: 1.3089969389957472  # 75 degrees
     enforce_forward_dot: true
     always_target_articulations: true

--- a/mir_navigation/config/dwb_local_planner_params.yaml
+++ b/mir_navigation/config/dwb_local_planner_params.yaml
@@ -50,7 +50,7 @@ DWBLocalPlanner:
   # Critics (trajectory scoring)
   #default_critic_namespaces: [dwb_critics, mir_dwb_critics]
   # critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathFollowerCritic]
-  critics: [PathFollowerCritic]
+  critics: [RotateToGoal, PathFollowerCritic]
   RotateToGoal:
     scale: 10.0
     # lookahead_time: -1.0
@@ -78,7 +78,7 @@ DWBLocalPlanner:
     always_target_articulations: true
     plan_alignment_position_tolerance: 0.15
     plan_alignment_yaw_tolerance: 3.14159265358979323846
-    xy_goal_tolerance: 0.20
+    xy_goal_tolerance: 0.10
     yaw_goal_tolerance: 0.15
 
 

--- a/mir_navigation/config/dwb_local_planner_params.yaml
+++ b/mir_navigation/config/dwb_local_planner_params.yaml
@@ -49,7 +49,7 @@ DWBLocalPlanner:
 
   # Critics (trajectory scoring)
   #default_critic_namespaces: [dwb_critics, mir_dwb_critics]
-  critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathFollowerCritic]
+  critics: [RotateToGoal, ObstacleFootprint, PathAlign, PathDistPruned, PathFollower]
   RotateToGoal:
     scale: 100.0
     # lookahead_time: -1.0
@@ -65,7 +65,7 @@ DWBLocalPlanner:
   PathDistPruned:
     scale: 32.0            # default: 32.0  mir: 32.0   - weighting for how much it should stick to the global path plan
     class: 'mir_dwb_critics::PathDistPruned'
-  PathFollowerCritic:
+  PathFollower:
     scale: 24.0            # default: 24.0  mir: 48.0   - weighting for how much it should attempt to reach its goal
     heading_scale: 0.1
     class: 'mir_dwb_critics::PathFollowerCritic'

--- a/mir_navigation/launch/move_base.xml
+++ b/mir_navigation/launch/move_base.xml
@@ -24,7 +24,7 @@
     </node>
 
     <node pkg="mir_navigation" type="global_plan_debug_viz.py" name="global_plan_debug_viz" output="screen">
-        <param name="global_plan_topic" value="move_base_node/SBPLLatticePlanner/plan" />
+        <param name="global_plan_topic" value="move_base_node/DWBLocalPlanner/transformed_global_plan" />
         <param name="marker_frame" value="$(arg prefix)base_link" />
     </node>
 </launch>

--- a/mir_navigation/launch/move_base.xml
+++ b/mir_navigation/launch/move_base.xml
@@ -22,4 +22,9 @@
         <remap from="map" to="/map" />
         <remap from="marker" to="move_base_node/DWBLocalPlanner/markers" />
     </node>
+
+    <node pkg="mir_navigation" type="global_plan_debug_viz.py" name="global_plan_debug_viz" output="screen">
+        <param name="global_plan_topic" value="move_base_node/SBPLLatticePlanner/plan" />
+        <param name="marker_frame" value="$(arg prefix)base_link" />
+    </node>
 </launch>

--- a/mir_navigation/nodes/global_plan_debug_viz.py
+++ b/mir_navigation/nodes/global_plan_debug_viz.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import rospy
+from geometry_msgs.msg import PoseArray
+from nav_msgs.msg import Path
+from visualization_msgs.msg import Marker
+
+
+class GlobalPlanDebugViz:
+    def __init__(self):
+        self._plan_counter = 0
+
+        default_plan_topic = rospy.get_param('~default_global_plan_topic', 'move_base_node/SBPLLatticePlanner/plan')
+        plan_topic = rospy.get_param('~global_plan_topic', default_plan_topic)
+
+        pose_array_topic = rospy.get_param('~pose_array_topic', 'global_plan_pose_array')
+        marker_topic = rospy.get_param('~marker_topic', 'global_plan_marker')
+
+        self._marker_frame = rospy.get_param('~marker_frame', 'base_link')
+        self._marker_height = rospy.get_param('~marker_height', 0.8)
+        self._marker_scale = rospy.get_param('~marker_scale', 0.2)
+        self._marker_ns = rospy.get_param('~marker_ns', 'global_plan_counter')
+        self._marker_id = rospy.get_param('~marker_id', 0)
+        self._marker_color = {
+            'r': rospy.get_param('~marker_color_r', 1.0),
+            'g': rospy.get_param('~marker_color_g', 1.0),
+            'b': rospy.get_param('~marker_color_b', 1.0),
+            'a': rospy.get_param('~marker_color_a', 1.0),
+        }
+
+        self._pose_array_pub = rospy.Publisher(pose_array_topic, PoseArray, queue_size=1, latch=True)
+        self._marker_pub = rospy.Publisher(marker_topic, Marker, queue_size=1, latch=True)
+        self._plan_sub = rospy.Subscriber(plan_topic, Path, self._plan_callback, queue_size=1)
+
+        rospy.loginfo('global_plan_debug_viz listening to %s', plan_topic)
+
+    def _plan_callback(self, msg: Path):
+        self._plan_counter += 1
+        self._publish_pose_array(msg)
+        self._publish_counter_marker()
+
+    def _publish_pose_array(self, path_msg: Path):
+        pose_array = PoseArray()
+        pose_array.header = path_msg.header
+        pose_array.poses = [pose.pose for pose in path_msg.poses]
+        self._pose_array_pub.publish(pose_array)
+
+    def _publish_counter_marker(self):
+        marker = Marker()
+        marker.header.frame_id = self._marker_frame
+        marker.header.stamp = rospy.Time.now()
+        marker.ns = self._marker_ns
+        marker.id = self._marker_id
+        marker.type = Marker.TEXT_VIEW_FACING
+        marker.action = Marker.ADD
+        marker.pose.position.x = 0.0
+        marker.pose.position.y = 0.0
+        marker.pose.position.z = self._marker_height
+        marker.pose.orientation.w = 1.0
+        marker.scale.z = self._marker_scale
+        marker.color.r = self._marker_color['r']
+        marker.color.g = self._marker_color['g']
+        marker.color.b = self._marker_color['b']
+        marker.color.a = self._marker_color['a']
+        marker.text = str(self._plan_counter)
+        marker.lifetime = rospy.Duration(0.0)
+
+        self._marker_pub.publish(marker)
+
+
+def main():
+    rospy.init_node('global_plan_debug_viz')
+    GlobalPlanDebugViz()
+    rospy.spin()
+
+
+if __name__ == '__main__':
+    main()

--- a/mir_navigation/nodes/global_plan_debug_viz.py
+++ b/mir_navigation/nodes/global_plan_debug_viz.py
@@ -1,5 +1,33 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2018-2022, Martin Günther (DFKI GmbH) and contributors
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 import rospy
 from geometry_msgs.msg import PoseArray
 from nav_msgs.msg import Path

--- a/mir_navigation/nodes/global_plan_debug_viz.py
+++ b/mir_navigation/nodes/global_plan_debug_viz.py
@@ -28,6 +28,19 @@ class GlobalPlanDebugViz:
             'a': rospy.get_param('~marker_color_a', 1.0),
         }
 
+        skip_param = rospy.get_param('~number_of_poses_to_skip', 7)
+        try:
+            skip_param = int(skip_param)
+        except (TypeError, ValueError):
+            rospy.logwarn("number_of_poses_to_skip must be an integer, got %s. Using 0 (no skipping).", skip_param)
+            skip_param = 0
+
+        if skip_param < 0:
+            rospy.logwarn("number_of_poses_to_skip cannot be negative. Using 0 (no skipping).")
+            skip_param = 0
+
+        self._poses_to_skip = skip_param
+
         self._pose_array_pub = rospy.Publisher(pose_array_topic, PoseArray, queue_size=1, latch=True)
         self._marker_pub = rospy.Publisher(marker_topic, Marker, queue_size=1, latch=True)
         self._plan_sub = rospy.Subscriber(plan_topic, Path, self._plan_callback, queue_size=1)
@@ -42,7 +55,12 @@ class GlobalPlanDebugViz:
     def _publish_pose_array(self, path_msg: Path):
         pose_array = PoseArray()
         pose_array.header = path_msg.header
-        pose_array.poses = [pose.pose for pose in path_msg.poses]
+
+        if self._poses_to_skip <= 0:
+            pose_array.poses = [pose.pose for pose in path_msg.poses]
+        else:
+            pose_array.poses = [pose.pose for idx, pose in enumerate(path_msg.poses) if idx % self._poses_to_skip == 0]
+
         self._pose_array_pub.publish(pose_array)
 
     def _publish_counter_marker(self):

--- a/mir_navigation/package.xml
+++ b/mir_navigation/package.xml
@@ -25,13 +25,17 @@
   <exec_depend>dwb_plugins</exec_depend>         <!-- for dwb_local_planner -->
   <!-- <exec_depend>eband_local_planner</exec_depend> -->
   <exec_depend>hector_mapping</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>map_server</exec_depend>
   <exec_depend>mir_driver</exec_depend>
   <exec_depend>mir_dwb_critics</exec_depend>     <!-- for dwb_local_planner -->
   <exec_depend>mir_gazebo</exec_depend>
   <exec_depend>move_base</exec_depend>
   <exec_depend>nav_core_adapter</exec_depend>    <!-- for dwb_local_planner -->
+  <exec_depend>nav_msgs</exec_depend>
   <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>sbpl_lattice_planner</exec_depend>
+  <exec_depend>rospy</exec_depend>
   <exec_depend>teb_local_planner</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
 </package>


### PR DESCRIPTION
- Added new DWB critic called path follower that tries to follow the global plan as close as possible.
- Configured separate critic on top to correct final heading near the goal

NOTE: Robot speed is reduced under current physics settings; enabling fast physics mitigates the problem

Tested in simulation; navigation through tight spaces shows improvement.

Final NOTE: Made almost entirely by OpenAI codex under my multiple and detailed instructions over several days.